### PR TITLE
feat(46): simulator - calculate api potential solar

### DIFF
--- a/faverton-nuxt3/app/components/calc/NavigationDrawers.vue
+++ b/faverton-nuxt3/app/components/calc/NavigationDrawers.vue
@@ -2,19 +2,25 @@
 import type { PVGISData } from "~/types/potential-solar";
 
 const props = defineProps<{
-  // TODO: ajouter le type correct
   solarPotential?: PVGISData
 }>();
 
 const rail = ref(true);
 const drawer = ref(true);
 
-// TODO: structure prop passer à composant FavertonDoughnut
-// - passe just potential energie annuel pour mvp
 const potentialSolarTotals = computed(() => {
   if (props.solarPotential === undefined) return;
   return props.solarPotential?.outputs;
 });
+
+const { data } = await useFetch(`/api/calc/solar-potential/price-year`, {
+  params: {
+    annualKwh: 1481.69,
+    surface: 3,
+  },
+});
+
+console.log(data.value);
 </script>
 
 <template>
@@ -44,7 +50,7 @@ const potentialSolarTotals = computed(() => {
       density="compact"
       nav
     >
-      <VListItem prepend-icon="mdi-account">
+      <VListItem>
         Il faut saisir une address dans le chemps de recherch :)
       </VListItem>
     </VList>

--- a/faverton-nuxt3/app/types/amount-euros-per-year.ts
+++ b/faverton-nuxt3/app/types/amount-euros-per-year.ts
@@ -1,0 +1,6 @@
+export type AmountEurosPerYear = {
+  averageAnnualProduction: number
+  surfaceAreaInSquareMeters: number
+  edfPrice: number
+  highPerformancePanel: string
+};

--- a/faverton-nuxt3/app/types/potential-solar.ts
+++ b/faverton-nuxt3/app/types/potential-solar.ts
@@ -1,189 +1,188 @@
 export type PVGISData = {
-    inputs: Inputs;
-    outputs: Outputs;
-    meta: Meta;
-  };
-  
-  export type Inputs = {
-    location: Location;
-    meteo_data: MeteoData;
-    mounting_system: MountingSystem;
-    pv_module: PVModule;
-    economic_data: EconomicData;
-  };
-  
-  export type Location = {
-    latitude: number;
-    longitude: number;
-    elevation: number;
-  };
-  
-  export type MeteoData = {
-    radiation_db: string;
-    meteo_db: string;
-    year_min: number;
-    year_max: number;
-    use_horizon: boolean;
-    horizon_db: string;
-  };
-  
-  export type MountingSystem = {
-    fixed: {
-      slope: {
-        value: number;
-        optimal: boolean;
-      };
-      azimuth: {
-        value: number;
-        optimal: boolean;
-      };
-      type: string;
-    };
-  };
-  
-  export type PVModule = {
-    technology: string;
-    peak_power: number;
-    system_loss: number;
-  };
-  
-  export type EconomicData = {
-    system_cost: number | null;
-    interest: number | null;
-    lifetime: number | null;
-  };
-  
-  export type Outputs = {
-    monthly: {
-      fixed: MonthlyData[];
-    };
-    totals: {
-      fixed: TotalsData;
-    };
-  };
-  
-  export type MonthlyData = {
-    month: number;
-    E_d: number;
-    E_m: number;
-    "H(i)_d": number;
-    "H(i)_m": number;
-    SD_m: number;
-  };
-  
-  export type TotalsData = {
-    E_d: number;
-    E_m: number;
-    E_y: number;
-    "H(i)_d": number;
-    "H(i)_m": number;
-    "H(i)_y": number;
-    SD_m: number;
-    SD_y: number;
-    l_aoi: number;
-    l_spec: string;
-    l_tg: number;
-    l_total: number;
-  };
-  
-  export type Meta = {
-    inputs: MetaInputs;
-    outputs: MetaOutputs;
-  };
-  
-  export type MetaInputs = {
-    location: MetaLocation;
-    meteo_data: MetaMeteoData;
-    mounting_system: MetaMountingSystem;
-    pv_module: MetaPVModule;
-    economic_data: MetaEconomicData;
-  };
-  
-  export type MetaLocation = {
-    description: string;
-    variables: {
-      latitude: MetaVariable;
-      longitude: MetaVariable;
-      elevation: MetaVariable;
-    };
-  };
-  
-  export type MetaMeteoData = {
-    description: string;
-    variables: {
-      radiation_db: MetaVariable;
-      meteo_db: MetaVariable;
-      year_min: MetaVariable;
-      year_max: MetaVariable;
-      use_horizon: MetaVariable;
-      horizon_db: MetaVariable;
-    };
-  };
-  
-  export type MetaMountingSystem = {
-    description: string;
-    choices: string;
-    fields: {
-      slope: MetaVariable;
-      azimuth: MetaVariable;
-    };
-  };
-  
-  export type MetaPVModule = {
-    description: string;
-    variables: {
-      technology: MetaVariable;
-      peak_power: MetaVariable;
-      system_loss: MetaVariable;
-    };
-  };
-  
-  export type MetaEconomicData = {
-    description: string;
-    variables: {
-      system_cost: MetaVariable;
-      interest: MetaVariable;
-      lifetime: MetaVariable;
-    };
-  };
-  
-  export type MetaVariable = {
-    description: string;
-    units?: string;
-  };
-  
-  export type MetaOutputs = {
-    monthly: MetaMonthly;
-    totals: MetaTotals;
-  };
-  
-  export type MetaMonthly = {
-    type: string;
-    timestamp: string;
-    variables: {
-      E_d: MetaVariable;
-      E_m: MetaVariable;
-      "H(i)_d": MetaVariable;
-      "H(i)_m": MetaVariable;
-      SD_m: MetaVariable;
-    };
-  };
-  
-  export type MetaTotals = {
-    type: string;
-    variables: {
-      E_d: MetaVariable;
-      E_m: MetaVariable;
-      E_y: MetaVariable;
-      "H(i)_d": MetaVariable;
-      "H(i)_m": MetaVariable;
-      "H(i)_y": MetaVariable;
-      SD_m: MetaVariable;
-      SD_y: MetaVariable;
-      l_aoi: MetaVariable;
-      l_spec: MetaVariable;
-      l_tg: MetaVariable;
-      l_total: MetaVariable;
-    };
-  };
-  
+  inputs: Inputs
+  outputs: Outputs
+  meta: Meta
+};
+
+export type Inputs = {
+  location: Location
+  meteo_data: MeteoData
+  mounting_system: MountingSystem
+  pv_module: PVModule
+  economic_data: EconomicData
+};
+
+export type Location = {
+  latitude: number
+  longitude: number
+  elevation: number
+};
+
+export type MeteoData = {
+  radiation_db: string
+  meteo_db: string
+  year_min: number
+  year_max: number
+  use_horizon: boolean
+  horizon_db: string
+};
+
+export type MountingSystem = {
+  fixed: {
+    slope: {
+      value: number
+      optimal: boolean
+    }
+    azimuth: {
+      value: number
+      optimal: boolean
+    }
+    type: string
+  }
+};
+
+export type PVModule = {
+  technology: string
+  peak_power: number
+  system_loss: number
+};
+
+export type EconomicData = {
+  system_cost: number | null
+  interest: number | null
+  lifetime: number | null
+};
+
+export type Outputs = {
+  monthly: {
+    fixed: MonthlyData[]
+  }
+  totals: {
+    fixed: TotalsData
+  }
+};
+
+export type MonthlyData = {
+  "month": number
+  "E_d": number
+  "E_m": number
+  "H(i)_d": number
+  "H(i)_m": number
+  "SD_m": number
+};
+
+export type TotalsData = {
+  "E_d": number
+  "E_m": number
+  "E_y": number
+  "H(i)_d": number
+  "H(i)_m": number
+  "H(i)_y": number
+  "SD_m": number
+  "SD_y": number
+  "l_aoi": number
+  "l_spec": string
+  "l_tg": number
+  "l_total": number
+};
+
+export type Meta = {
+  inputs: MetaInputs
+  outputs: MetaOutputs
+};
+
+export type MetaInputs = {
+  location: MetaLocation
+  meteo_data: MetaMeteoData
+  mounting_system: MetaMountingSystem
+  pv_module: MetaPVModule
+  economic_data: MetaEconomicData
+};
+
+export type MetaLocation = {
+  description: string
+  variables: {
+    latitude: MetaVariable
+    longitude: MetaVariable
+    elevation: MetaVariable
+  }
+};
+
+export type MetaMeteoData = {
+  description: string
+  variables: {
+    radiation_db: MetaVariable
+    meteo_db: MetaVariable
+    year_min: MetaVariable
+    year_max: MetaVariable
+    use_horizon: MetaVariable
+    horizon_db: MetaVariable
+  }
+};
+
+export type MetaMountingSystem = {
+  description: string
+  choices: string
+  fields: {
+    slope: MetaVariable
+    azimuth: MetaVariable
+  }
+};
+
+export type MetaPVModule = {
+  description: string
+  variables: {
+    technology: MetaVariable
+    peak_power: MetaVariable
+    system_loss: MetaVariable
+  }
+};
+
+export type MetaEconomicData = {
+  description: string
+  variables: {
+    system_cost: MetaVariable
+    interest: MetaVariable
+    lifetime: MetaVariable
+  }
+};
+
+export type MetaVariable = {
+  description: string
+  units?: string
+};
+
+export type MetaOutputs = {
+  monthly: MetaMonthly
+  totals: MetaTotals
+};
+
+export type MetaMonthly = {
+  type: string
+  timestamp: string
+  variables: {
+    "E_d": MetaVariable
+    "E_m": MetaVariable
+    "H(i)_d": MetaVariable
+    "H(i)_m": MetaVariable
+    "SD_m": MetaVariable
+  }
+};
+
+export type MetaTotals = {
+  type: string
+  variables: {
+    "E_d": MetaVariable
+    "E_m": MetaVariable
+    "E_y": MetaVariable
+    "H(i)_d": MetaVariable
+    "H(i)_m": MetaVariable
+    "H(i)_y": MetaVariable
+    "SD_m": MetaVariable
+    "SD_y": MetaVariable
+    "l_aoi": MetaVariable
+    "l_spec": MetaVariable
+    "l_tg": MetaVariable
+    "l_total": MetaVariable
+  }
+};

--- a/faverton-nuxt3/server/api/calc/solar-potential/price-year.ts
+++ b/faverton-nuxt3/server/api/calc/solar-potential/price-year.ts
@@ -1,0 +1,24 @@
+export default defineEventHandler((event) => {
+  const query = getQuery(event);
+
+  const EDF_PRICE = 0.1269;
+  const HIGH_PERFORMANCE_PANEL = 0.2;
+
+  const annualKwh = Number(query.annualKwh);
+  const surfaceArea = Number(query.surface);
+
+  if (isNaN(annualKwh) || isNaN(surfaceArea)) {
+    return {
+      error: `Paramètres invalides`,
+      status: 400,
+    };
+  }
+
+  const amountEurosPerYear = annualKwh * surfaceArea * EDF_PRICE * HIGH_PERFORMANCE_PANEL;
+
+  return {
+    annualKwh,
+    surfaceArea,
+    amountEurosPerYear,
+  };
+});


### PR DESCRIPTION
This pull request includes several changes to the `faverton-nuxt3` project, focusing on enhancing type definitions, adding a new API handler, and modifying a Vue component. The most important changes are summarized below:

### Type Definitions:

* Added a new type `AmountEurosPerYear` to represent the structure of data related to annual production and surface area (`faverton-nuxt3/app/types/amount-euros-per-year.ts`).
* Updated the `PVGISData` type and its related subtypes to use a more consistent and clean format by removing semicolons and adding line breaks (`faverton-nuxt3/app/types/potential-solar.ts`).

### API Handler:

* Introduced a new API handler to calculate the price per year based on annual kWh and surface area. This handler validates the input parameters and returns the calculated amount in euros (`faverton-nuxt3/server/api/calc/solar-potential/price-year.ts`).

### Vue Component:

* Modified `NavigationDrawers.vue` to remove outdated TODO comments and added a new fetch call to retrieve solar potential price data, logging the response (`faverton-nuxt3/app/components/calc/NavigationDrawers.vue`).
* Updated the template within `NavigationDrawers.vue` to remove the `prepend-icon` attribute from a `VListItem` component (`faverton-nuxt3/app/components/calc/NavigationDrawers.vue`).