### PR TITLE
feat(49): simulator - fetch price year

### DIFF
--- a/faverton-nuxt3/app/components/calc/Card.vue
+++ b/faverton-nuxt3/app/components/calc/Card.vue
@@ -5,8 +5,14 @@ import type { FormError, FormSubmitEvent } from '#ui/types';
 
 const searchTerm = ref<string>(``);
 const surface = ref<number>(1);
+const selectedFeatureCollection = ref<FeatureCollection | null>(null);
+const coordinates = ref<Array<number>>([]);
+const state = reactive({
+  inputValue: undefined,
+});
 
 const { data, isLoading, error, refetch } = useAddressSearch(searchTerm);
+const { data: solarPotential, isLoading: solarLoading, error: solarError } = useSolarPotential(coordinates);
 
 const items = computed(
   () =>
@@ -26,30 +32,21 @@ watch(searchTerm, () => {
   return () => clearTimeout(timeout);
 });
 
-const selectedFeatureCollection = ref<FeatureCollection | null>(null);
-const coordinates = ref<Array<number>>([]);
-
-const { data: solarPotential, isLoading: solarLoading, error: solarError } = useSolarPotential(coordinates);
-
-const onSelect = (item: FeatureCollection | null) => {
-  selectedFeatureCollection.value = item;
-  coordinates.value = item?.features.geometry.coordinates ?? [];
-  emit(`update:modelValue`, item);
-};
-
 // @ts-expect-error: feature does not have a defined type
 const geoStyler = feature => ({
   opacity: feature.properties.code / 100000,
-});
-
-const state = reactive({
-  inputValue: undefined,
 });
 
 const validate = (state: { inputValue: number | undefined }): FormError[] => {
   const errors = [];
   if (!state.inputValue) errors.push({ path: `number`, message: `La valeur doit être entre 1 et 100` });
   return errors;
+};
+
+const onSelect = (item: FeatureCollection | null) => {
+  selectedFeatureCollection.value = item;
+  coordinates.value = item?.features.geometry.coordinates ?? [];
+  emit(`update:modelValue`, item);
 };
 
 async function onSubmit(event: FormSubmitEvent<{ inputValue: number }>) {

--- a/faverton-nuxt3/app/components/calc/Card.vue
+++ b/faverton-nuxt3/app/components/calc/Card.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { useSolarPotential } from "~/composables/useSolarPotential";
 import type { FeatureCollection, Feature } from "~/types/address/search";
+import type { FormError, FormSubmitEvent } from '#ui/types';
 
 const searchTerm = ref<string>(``);
+const surface = ref<number>(1);
 
 const { data, isLoading, error, refetch } = useAddressSearch(searchTerm);
 
@@ -40,20 +42,19 @@ const geoStyler = feature => ({
   opacity: feature.properties.code / 100000,
 });
 
-// surface
-const inputValue = ref<number>(1);
-const surface = ref<number>(1);
-const validate = (inputValue) => {
-  if (inputValue < 1 || inputValue > 100) {
-    return `La valeur doit être entre 1 et 100`;
-  }
-  return true;
+const state = reactive({
+  inputValue: undefined,
+});
+
+const validate = (state: { inputValue: number | undefined }): FormError[] => {
+  const errors = [];
+  if (!state.inputValue) errors.push({ path: `number`, message: `La valeur doit être entre 1 et 100` });
+  return errors;
 };
-const onSubmit = () => {
-  // Traitement après soumission
-  surface.value = inputValue.value;
-  console.log(`Valeur soumise:`, surface.value);
-};
+
+async function onSubmit(event: FormSubmitEvent<{ inputValue: number }>) {
+  surface.value = event.data.inputValue;
+}
 </script>
 
 <template>
@@ -85,11 +86,15 @@ const onSubmit = () => {
       </VAutocomplete>
       <UForm
         :validate="validate"
+        :state="state"
         @submit="onSubmit"
       >
-        <UFormGroup label="Entrez un nombre entre 1 et 100">
+        <UFormGroup
+          label="Entrez un nombre entre 1 et 100"
+          name="number"
+        >
           <UInput
-            v-model="inputValue"
+            v-model="state.inputValue"
             type="number"
             :min="1"
             :max="100"

--- a/faverton-nuxt3/app/components/calc/NavigationDrawers.vue
+++ b/faverton-nuxt3/app/components/calc/NavigationDrawers.vue
@@ -15,14 +15,18 @@ const potentialSolarTotals = computed(() => {
   return props.solarPotential?.outputs;
 });
 
-const { data } = await useFetch(`/api/calc/solar-potential/price-year`, {
-  params: {
-    annualKwh: 1481.69,
-    surface: 3,
-  },
+const queryParams = computed(() => ({
+  annualKwh: potentialSolarTotals.value?.totals.fixed.E_y ?? 0,
+  surface: props.surface,
+}));
+
+const { data, status } = useLazyFetch(`/api/calc/solar-potential/price-year`, {
+  query: queryParams,
 });
 
-console.log(`fetch potential solar year`, data.value, `surface `, props.surface);
+const canDisplayGraph = computed(() => {
+  return !!props.surface && !!potentialSolarTotals.value && !!data.value;
+});
 </script>
 
 <template>
@@ -49,7 +53,7 @@ console.log(`fetch potential solar year`, data.value, `surface `, props.surface)
     <v-divider />
 
     <div
-      v-if="solarLoading"
+      v-if="status === 'pending'"
       class="flex items-center justify-center h-full "
     >
       <VProgressCircular
@@ -61,7 +65,7 @@ console.log(`fetch potential solar year`, data.value, `surface `, props.surface)
 
     <template v-else>
       <VList
-        v-if="!potentialSolarTotals"
+        v-if="!canDisplayGraph"
         density="compact"
         nav
       >
@@ -76,7 +80,10 @@ console.log(`fetch potential solar year`, data.value, `surface `, props.surface)
         nav
       >
         <VListItem>
-          <FavertonDoughnut :potential-solar-totals />
+          <VListItem>
+            {{ data }}
+            <br>
+          </VListItem>
         </VListItem>
       </VList>
     </template>

--- a/faverton-nuxt3/server/api/calc/solar-potential/price-year.ts
+++ b/faverton-nuxt3/server/api/calc/solar-potential/price-year.ts
@@ -7,7 +7,7 @@ export default defineEventHandler((event) => {
   const annualKwh = Number(query.annualKwh);
   const surfaceArea = Number(query.surface);
 
-  if (isNaN(annualKwh) || isNaN(surfaceArea)) {
+  if (isNaN(annualKwh) || isNaN(surfaceArea) || surfaceArea == 0) {
     return {
       error: `Paramètres invalides`,
       status: 400,


### PR DESCRIPTION
This pull request includes several updates to the `faverton-nuxt3` project, focusing on improving form validation, updating API fetch logic, and refining component behavior. The most important changes include modifying the form validation and submission logic, updating the API call parameters, and enhancing the conditional rendering in components.

### Form Validation and Submission Logic:

* [`faverton-nuxt3/app/components/calc/Card.vue`](diffhunk://#diff-548c21c31457198592f363b1816f05b5645bb11354ab92029230f4e4eb7da1b3R4-R7): Replaced the `inputValue` ref with a reactive `state` object and updated the `validate` function to return an array of `FormError` objects. The `onSubmit` function now processes the form submission using the `FormSubmitEvent` type. [[1]](diffhunk://#diff-548c21c31457198592f363b1816f05b5645bb11354ab92029230f4e4eb7da1b3R4-R7) [[2]](diffhunk://#diff-548c21c31457198592f363b1816f05b5645bb11354ab92029230f4e4eb7da1b3L43-R57) [[3]](diffhunk://#diff-548c21c31457198592f363b1816f05b5645bb11354ab92029230f4e4eb7da1b3R89-R97)

### API Fetch Logic:

* [`faverton-nuxt3/app/components/calc/NavigationDrawers.vue`](diffhunk://#diff-0a061705550c882cb12002e59c4f3866a114dcc1b4d614eeeaa48800e1ea844cL18-R29): Updated the API call to use `useLazyFetch` with computed query parameters and added a `canDisplayGraph` computed property to determine when to display the graph.

### Component Behavior:

* [`faverton-nuxt3/app/components/calc/NavigationDrawers.vue`](diffhunk://#diff-0a061705550c882cb12002e59c4f3866a114dcc1b4d614eeeaa48800e1ea844cL52-R56): Replaced conditional checks for `solarLoading` and `potentialSolarTotals` with `status` and `canDisplayGraph` respectively, to improve the rendering logic. [[1]](diffhunk://#diff-0a061705550c882cb12002e59c4f3866a114dcc1b4d614eeeaa48800e1ea844cL52-R56) [[2]](diffhunk://#diff-0a061705550c882cb12002e59c4f3866a114dcc1b4d614eeeaa48800e1ea844cL64-R68) [[3]](diffhunk://#diff-0a061705550c882cb12002e59c4f3866a114dcc1b4d614eeeaa48800e1ea844cL79-R86)

### Error Handling:

* [`faverton-nuxt3/server/api/calc/solar-potential/price-year.ts`](diffhunk://#diff-da04366de9d404183923f46f0269fd771d639aede80147b1eeae471920154c60L10-R10): Added a check for `surfaceArea` being zero to the validation logic for query parameters.