### PR TITLE
feat(41): simulator - display result one year amount

### DIFF
--- a/faverton-nuxt3/app/components/calc/Card.vue
+++ b/faverton-nuxt3/app/components/calc/Card.vue
@@ -8,11 +8,11 @@ const surface = ref<number>(1);
 const selectedFeatureCollection = ref<FeatureCollection | null>(null);
 const coordinates = ref<Array<number>>([]);
 const state = reactive({
-  inputValue: undefined,
+  inputValue: 1,
 });
 
 const { data, isLoading, error, refetch } = useAddressSearch(searchTerm);
-const { data: solarPotential, isLoading: solarLoading, error: solarError } = useSolarPotential(coordinates);
+const { data: solarPotential, error: solarError } = useSolarPotential(coordinates);
 
 const items = computed(
   () =>
@@ -127,7 +127,6 @@ async function onSubmit(event: FormSubmitEvent<{ inputValue: number }>) {
     >
       <CalcNavigationDrawers
         :solar-potential
-        :solar-loading
         :surface
       />
     </v-app>

--- a/faverton-nuxt3/app/components/calc/NavigationDrawers.vue
+++ b/faverton-nuxt3/app/components/calc/NavigationDrawers.vue
@@ -1,31 +1,24 @@
 <script setup lang="ts">
 import type { PVGISData } from "~/types/potential-solar";
+import type { AmountEurosPerYear } from "~/types/amount-euros-per-year";
 
 const props = defineProps<{
   solarPotential?: PVGISData
-  solarLoading?: boolean
   surface?: number
 }>();
 
 const rail = ref(true);
 const drawer = ref(true);
 
-const potentialSolarTotals = computed(() => {
-  if (props.solarPotential === undefined) return;
-  return props.solarPotential?.outputs;
-});
-
 const queryParams = computed(() => ({
-  annualKwh: potentialSolarTotals.value?.totals.fixed.E_y ?? 0,
+  annualKwh: props.solarPotential?.outputs.totals.fixed.E_y ?? 0,
   surface: props.surface,
 }));
 
+const amountEurosPerYear = computed<AmountEurosPerYear>(() => data.value as AmountEurosPerYear);
+
 const { data, status } = useLazyFetch(`/api/calc/solar-potential/price-year`, {
   query: queryParams,
-});
-
-const canDisplayGraph = computed(() => {
-  return !!props.surface && !!potentialSolarTotals.value && !!data.value;
 });
 </script>
 
@@ -50,8 +43,6 @@ const canDisplayGraph = computed(() => {
     :rail="!rail"
     temporary
   >
-    <v-divider />
-
     <div
       v-if="status === 'pending'"
       class="flex items-center justify-center h-full "
@@ -65,13 +56,11 @@ const canDisplayGraph = computed(() => {
 
     <template v-else>
       <VList
-        v-if="!canDisplayGraph"
+        v-if="!solarPotential"
         density="compact"
         nav
       >
-        <VListItem>
-          Il faut saisir une address dans le chemps de recherch et le surface :)
-        </VListItem>
+        Il faut saisir une address dans le chemps de recherch et le surface :)
       </VList>
 
       <VList
@@ -79,12 +68,7 @@ const canDisplayGraph = computed(() => {
         density="compact"
         nav
       >
-        <VListItem>
-          <VListItem>
-            {{ data }}
-            <br>
-          </VListItem>
-        </VListItem>
+        <FavertonCardYear :amount-euros-per-year />
       </VList>
     </template>
   </VNavigationDrawer>

--- a/faverton-nuxt3/app/components/faverton/btn/FavertonBtnDrawers.vue
+++ b/faverton-nuxt3/app/components/faverton/btn/FavertonBtnDrawers.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+const props = defineProps<{
+  drawer: boolean
+}>();
+const emit = defineEmits([`update:drawer`]);
+</script>
+
+<template>
+  <VNavigationDrawer
+    permanent
+    location="right"
+    :width="50"
+  >
+    <template #append>
+      <VBtn
+        :icon="drawer ? 'mdi-chevron-right' : 'mdi-chevron-left'"
+        @click.stop="emit('update:drawer', !props.drawer)"
+      />
+    </template>
+  </VNavigationDrawer>
+</template>

--- a/faverton-nuxt3/app/components/faverton/card/FavertonCardYear.vue
+++ b/faverton-nuxt3/app/components/faverton/card/FavertonCardYear.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import type { AmountEurosPerYear } from "~/types/amount-euros-per-year";
+
+defineProps<{
+  amountEurosPerYear: AmountEurosPerYear
+}>();
+</script>
+
+<template>
+  <div class="bg-blue-50 p-6 rounded-lg shadow-md">
+    <div class="grid grid-cols-3 gap-4">
+      <div class="text-center">
+        <h3 class="font-bold text-xl text-blue-600 text-nowrap">
+          🌞 Production Annuelle
+        </h3>
+        <p class="text-2xl font-semibold">
+          {{ amountEurosPerYear.annualKwh.toFixed(2) }} kWh
+        </p>
+      </div>
+      <div class="text-center">
+        <h3 class="font-bold text-xl text-green-600">
+          📏 Surface
+        </h3>
+        <p class="text-2xl font-semibold">
+          {{ amountEurosPerYear.surfaceArea }} m²
+        </p>
+      </div>
+      <div class="text-center">
+        <h3 class="font-bold text-xl text-emerald-600">
+          💶 Revenu Estimé
+        </h3>
+        <p class="text-2xl font-semibold">
+          {{ amountEurosPerYear.amountEurosPerYear.toFixed(2) }} €/an
+        </p>
+      </div>
+    </div>
+  </div>
+</template>

--- a/faverton-nuxt3/app/components/faverton/doughnut/FavertonDoughnut.vue
+++ b/faverton-nuxt3/app/components/faverton/doughnut/FavertonDoughnut.vue
@@ -5,13 +5,11 @@ import type { Outputs } from '~/types/potential-solar';
 
 ChartJS.register(Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale);
 
-const props = defineProps<{
+defineProps<{
   potentialSolarTotals?: Outputs
 }>();
 
-const annualPercentage = computed(() => parseFloat((props.potentialSolarTotals?.totals.fixed.E_y / props.potentialSolarTotals?.totals.fixed[`H(i)_y`] * 100).toFixed(2)));
-
-console.log(annualPercentage.value);
+// const annualPercentage = computed(() => parseFloat((props.potentialSolarTotals?.totals.fixed.E_y / props.potentialSolarTotals?.totals.fixed[`H(i)_y`] * 100).toFixed(2)));
 
 const chartData = {
   labels: [`January`, `February`, `March`, `April`, `May`, `June`, `July`, `August`, `September`, `October`, `November`, `December`],

--- a/faverton-nuxt3/app/types/amount-euros-per-year.ts
+++ b/faverton-nuxt3/app/types/amount-euros-per-year.ts
@@ -1,6 +1,5 @@
-export type AmountEurosPerYear = {
-  averageAnnualProduction: number
-  surfaceAreaInSquareMeters: number
-  edfPrice: number
-  highPerformancePanel: string
-};
+export interface AmountEurosPerYear {
+  annualKwh: number
+  surfaceArea: number
+  amountEurosPerYear: number
+}


### PR DESCRIPTION
This pull request includes several changes to the `faverton-nuxt3` project, focusing on improving the solar potential calculation and user interface components. The most important changes include updating component props, removing unused code, and adding new components for better data presentation.

### Component Updates:
* [`faverton-nuxt3/app/components/calc/Card.vue`](diffhunk://#diff-548c21c31457198592f363b1816f05b5645bb11354ab92029230f4e4eb7da1b3L11-R15): Removed the `solar-loading` prop from `CalcNavigationDrawers` and initialized `inputValue` to 1. [[1]](diffhunk://#diff-548c21c31457198592f363b1816f05b5645bb11354ab92029230f4e4eb7da1b3L11-R15) [[2]](diffhunk://#diff-548c21c31457198592f363b1816f05b5645bb11354ab92029230f4e4eb7da1b3L130)
* [`faverton-nuxt3/app/components/calc/NavigationDrawers.vue`](diffhunk://#diff-0a061705550c882cb12002e59c4f3866a114dcc1b4d614eeeaa48800e1ea844cR3-L29): Removed the `solarLoading` prop, and updated `queryParams` and `canDisplayGraph` computations. Added `amountEurosPerYear` computation. [[1]](diffhunk://#diff-0a061705550c882cb12002e59c4f3866a114dcc1b4d614eeeaa48800e1ea844cR3-L29) [[2]](diffhunk://#diff-0a061705550c882cb12002e59c4f3866a114dcc1b4d614eeeaa48800e1ea844cL53-L54) [[3]](diffhunk://#diff-0a061705550c882cb12002e59c4f3866a114dcc1b4d614eeeaa48800e1ea844cL68-R71)

### New Components:
* [`faverton-nuxt3/app/components/faverton/btn/FavertonBtnDrawers.vue`](diffhunk://#diff-fd17ce31a5a63fbc37f335937e354229cd987e3273b1f56ef144b5a0c407d2d8R1-R21): Added a new button component for toggling the navigation drawer.
* [`faverton-nuxt3/app/components/faverton/card/FavertonCardYear.vue`](diffhunk://#diff-64b4caf2c8c2dbab6353af5d56cef3c6418e17e84bec305802f5ac9ce973a786R1-R38): Added a new card component to display annual production, surface area, and estimated revenue.

### Type Definitions:
* [`faverton-nuxt3/app/types/amount-euros-per-year.ts`](diffhunk://#diff-204110559abaf7dc22b5e4123403c5d8750b98d47be44000a78de596d67c3fc6L1-R5): Changed `AmountEurosPerYear` from a type to an interface and updated its properties.

### Code Cleanup:
* [`faverton-nuxt3/app/components/faverton/doughnut/FavertonDoughnut.vue`](diffhunk://#diff-74d807f7151103194e1dd863fd9776a67e27005d53af7785c5666a3cd374d95dL8-R12): Commented out the unused `annualPercentage` computation.