### PR TITLE
feat(70): simulation - redirection to login when user don't connected

### DIFF
--- a/faverton-nuxt3/app/components/calc/CalcNavigationDrawers.vue
+++ b/faverton-nuxt3/app/components/calc/CalcNavigationDrawers.vue
@@ -62,6 +62,9 @@ function handlePanelClick(model: string) {
 
 // Form submission handler
 async function handleFormSubmit() {
+  if (userId.value !== user?.value?.id) {
+    navigateTo(`/user/login`);
+  }
   try {
     const res = await $fetch<SimulationResponse>(`/api/simulation`, {
       method: `POST`,
@@ -130,7 +133,7 @@ const isFormValid = computed(() =>
 
       <!-- Selection Summary -->
       <div class="p-3">
-        <p>Il faut choisir votre address et le surface en m2 avec le panel</p>
+        <p>Si vous êtes connecté, vous devez choisir votre adresse et la surface en m² avec le panel.</p>
 
         <div class="mt-3">
           <div v-if="addressProperty">

--- a/faverton-nuxt3/app/components/user/auth/UserAuthLogin.vue
+++ b/faverton-nuxt3/app/components/user/auth/UserAuthLogin.vue
@@ -15,7 +15,7 @@ const login = async () => {
   }
   else {
     message.value = `Connexion réussie`;
-    navigateTo(`/user/profile`);
+    navigateTo(`/simulator`);
   }
 };
 
@@ -26,8 +26,6 @@ const gotToRegister = () => {
 
 <template>
   <div class="flex flex-col justify-center h-screen items-center gap-3">
-    <!-- <AppHeader /> -->
-
     <h1>
       Se connecter
     </h1>


### PR DESCRIPTION
This pull request includes several changes to improve user authentication and navigation within the application. The most important changes include adding a user login check before form submission, updating navigation after successful login, and modifying user instructions for form completion.

Improvements to user authentication and navigation:

* [`faverton-nuxt3/app/components/calc/CalcNavigationDrawers.vue`](diffhunk://#diff-7477022e1482e000649be565015fbd3012a161f90f2f1f43a3f9d4eb8fb4b259R65-R67): Added a check to ensure the user is logged in before allowing form submission. If the user is not logged in, they are redirected to the login page.
* [`faverton-nuxt3/app/components/user/auth/UserAuthLogin.vue`](diffhunk://#diff-c34301cc5a494413de6387dea621ff45ec0fee36c6d4fe6d297108e8dcbbeba7L18-R18): Updated the navigation path after a successful login to redirect users to the simulator page instead of the user profile page.

Updates to user instructions:

* [`faverton-nuxt3/app/components/calc/CalcNavigationDrawers.vue`](diffhunk://#diff-7477022e1482e000649be565015fbd3012a161f90f2f1f43a3f9d4eb8fb4b259L133-R136): Modified the instruction text to clarify that users must be logged in to select their address and surface area.