### PR TITLE
feat(39): add monthly solar revenue graph

### DIFF
--- a/faverton-nuxt3/app/components/calc/CalcNavigationDrawers.vue
+++ b/faverton-nuxt3/app/components/calc/CalcNavigationDrawers.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { FetchError } from 'ofetch';
 import type { Properties } from '~/types/address/new-base-address-national';
+import type { AmountEurosPerMonths } from '~/types/amount-euros-per-months';
 import type { AmountEurosPerYear } from '~/types/amount-euros-per-year';
 import type { Simulation, SolarEnergy } from '~/types/simulation';
 
@@ -56,7 +57,7 @@ const queryParamsMonth = computed(() => ({
   solarEnergyId: simulation.value?.solar_energy.solar_energy_id ?? null,
 }));
 
-const { data: amountPerMonth } = useLazyFetch<AmountEurosPerYear>(`/api/simulation/price-month`, {
+const { data: amountPerMonth } = useLazyFetch<AmountEurosPerMonths>(`/api/simulation/price-month`, {
   query: queryParamsMonth,
   watch: [() => simulation.value?.solar_energy.solar_energy_id],
 });
@@ -182,7 +183,7 @@ const isFormValid = computed(() =>
       </div>
 
       <CalcSimulationYearlyAmount :amount-per-year />
-      <CalcSimulationMonthlyAmount />
+      <CalcSimulationMonthlyAmount :amount-per-month="amountPerMonth" />
 
       <CalcSimulationHistoryButtonRegister
         :simulation-id="simulationId"

--- a/faverton-nuxt3/app/components/calc/simulation/monthly-amount/CalcSimulationMonthlyAmount.vue
+++ b/faverton-nuxt3/app/components/calc/simulation/monthly-amount/CalcSimulationMonthlyAmount.vue
@@ -1,5 +1,66 @@
+<script setup lang="ts">
+import { Bar } from 'vue-chartjs';
+import { Chart as ChartJS, Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale } from 'chart.js';
+import type { AmountEurosPerMonths } from '~/types/amount-euros-per-months';
+
+const props = defineProps<{
+  amountPerMonth?: AmountEurosPerMonths
+}>();
+
+ChartJS.register(Title, Tooltip, Legend, BarElement, CategoryScale, LinearScale);
+
+const amountEurosPerMonth = computed<AmountEurosPerMonths>(() => props.amountPerMonth as AmountEurosPerMonths);
+
+const hasMonthlyData = computed(() =>
+  !!amountEurosPerMonth.value?.monthlyResults
+  && amountEurosPerMonth.value.monthlyResults.length > 0,
+);
+
+const chartData = computed(() => {
+  if (!hasMonthlyData.value) {
+    return { labels: [], datasets: [] };
+  }
+  const monthlyData = amountEurosPerMonth.value.monthlyResults;
+  return {
+    labels: monthlyData.map(item => item.month),
+    datasets: [
+      {
+        label: `Revenus mensuels (€)`,
+        backgroundColor: `#1f398c`,
+        data: monthlyData.map(item => item.euros),
+      },
+      {
+        label: `Énergie produite (kWh)`,
+        backgroundColor: `#4CAF50`,
+        data: monthlyData.map(item => item.energy),
+      },
+    ],
+  };
+});
+
+const chartOptions = ref({
+  responsive: true,
+  scales: {
+    y: {
+      beginAtZero: true,
+    },
+  },
+});
+</script>
+
 <template>
   <div>
-    hello
+    <Bar
+      v-if="hasMonthlyData"
+      id="my-chart-id"
+      :options="chartOptions"
+      :data="chartData"
+    />
+    <div
+      v-else
+      class="no-data-message"
+    >
+      Aucune donnée disponible pour afficher le graphique
+    </div>
   </div>
 </template>

--- a/faverton-nuxt3/app/types/amount-euros-per-months.ts
+++ b/faverton-nuxt3/app/types/amount-euros-per-months.ts
@@ -1,0 +1,11 @@
+export interface AmountEurosPerMonths {
+  surfaceArea: number
+  panelEfficiency: number
+  monthlyResults: MonthlyResult[]
+}
+
+export interface MonthlyResult {
+  month: string
+  energy: number
+  euros: number
+}


### PR DESCRIPTION
This pull request includes multiple changes to the `faverton-nuxt3` project, focusing on adding support for monthly simulation data and improving the related components and API. The most important changes include updating type definitions, modifying components to handle monthly data, and refactoring the API to return the correct format.

### Type Definitions and Imports:

* [`faverton-nuxt3/app/components/calc/CalcNavigationDrawers.vue`](diffhunk://#diff-7477022e1482e000649be565015fbd3012a161f90f2f1f43a3f9d4eb8fb4b259R4): Added `AmountEurosPerMonths` type import.
* [`faverton-nuxt3/app/types/amount-euros-per-months.ts`](diffhunk://#diff-ef5bfa41883bcaa902939e347be5027fe486256b03bba03000a637ff6840f4ebR1-R11): Created new interfaces `AmountEurosPerMonths` and `MonthlyResult`.

### Component Updates:

* [`faverton-nuxt3/app/components/ccalc/CalcNavigationDrawers.vue`](diffhunk://#diff-7477022e1482e000649be565015fbd3012a161f90f2f1f43a3f9d4eb8fb4b259L59-R60): Changed the type for `amountPerMonth` to `AmountEurosPerMonths` and updated `CalcSimulationMonthlyAmount` component to accept `amount-per-month` prop. [[1]](diffhunk://#diff-7477022e1482e000649be565015fbd3012a161f90f2f1f43a3f9d4eb8fb4b259L59-R60) [[2]](diffhunk://#diff-7477022e1482e000649be565015fbd3012a161f90f2f1f43a3f9d4eb8fb4b259L185-R186)
* [`faverton-nuxt3/app/components/calc/simulation/monthly-amount/CalcSimulationMonthlyAmount.vue`](diffhunk://#diff-d962f221a5f7b28c6297d9d6e4b4ca31c1c86dc2de338391c8143a204d803f5bR1-R64): Implemented the component to display a bar chart using `vue-chartjs` and `chart.js`, with data provided by the `amountPerMonth` prop.

### API Refactoring:

* [`faverton-nuxt3/server/api/simulation/price-month/index.get.ts`](diffhunk://#diff-f5d53be361a03fc542f247f56db2ab3aaabba34117f4dbd4d296bfcf9ae1de29R5): Updated the `MONTH_NAMES` from an object to an array, and refactored the logic to generate `monthlyResults` as an array of `MonthlyResult` objects. [[1]](diffhunk://#diff-f5d53be361a03fc542f247f56db2ab3aaabba34117f4dbd4d296bfcf9ae1de29R5) [[2]](diffhunk://#diff-f5d53be361a03fc542f247f56db2ab3aaabba34117f4dbd4d296bfcf9ae1de29L14-R18) [[3]](diffhunk://#diff-f5d53be361a03fc542f247f56db2ab3aaabba34117f4dbd4d296bfcf9ae1de29L54-R46) [[4]](diffhunk://#diff-f5d53be361a03fc542f247f56db2ab3aaabba34117f4dbd4d296bfcf9ae1de29L66-R67)