### PR TITLE
feat(75): navigation - add breadcrumb

### DIFF
--- a/faverton-nuxt3/app/components/user/auth/UserAuthLogin.vue
+++ b/faverton-nuxt3/app/components/user/auth/UserAuthLogin.vue
@@ -24,6 +24,21 @@ const login = async () => {
 
 <template>
   <div class="flex flex-col justify-center bg-yellow-100 h-screen items-center gap-3">
+    <div class="z-index-[999] fixed left-32 top-4">
+      <UBreadcrumb
+        :links="[{ label: 'Introduction', to: '/introduction' }, { label: 'Se connecter' }]"
+      >
+        <template #default="{ link, isActive }">
+          <UBadge
+            :color="isActive ? 'primary' : 'gray'"
+            class="rounded-full truncate"
+          >
+            {{ link.label }}
+          </UBadge>
+        </template>
+      </UBreadcrumb>
+    </div>
+
     <h1>
       Se connecter
     </h1>

--- a/faverton-nuxt3/app/components/user/auth/UserAuthRegister.vue
+++ b/faverton-nuxt3/app/components/user/auth/UserAuthRegister.vue
@@ -37,6 +37,20 @@ const register = async () => {
 
 <template>
   <div class="flex flex-col justify-center bg-yellow-100 h-screen items-center gap-3">
+    <div class="z-index-[999] fixed left-32 top-4">
+      <UBreadcrumb
+        :links="[{ label: 'Introduction', to: '/introduction' }, { label: 'Crée un compte' }]"
+      >
+        <template #default="{ link, isActive }">
+          <UBadge
+            :color="isActive ? 'primary' : 'gray'"
+            class="rounded-full truncate"
+          >
+            {{ link.label }}
+          </UBadge>
+        </template>
+      </UBreadcrumb>
+    </div>
     <h1>
       Crée un compte
     </h1>

--- a/faverton-nuxt3/app/components/user/profile/UserProfile.vue
+++ b/faverton-nuxt3/app/components/user/profile/UserProfile.vue
@@ -83,6 +83,20 @@ const signOut = async () => {
 
 <template>
   <div class="bg-yellow-100 h-screen flex flex-col justify-center items-center">
+    <div class="z-index-[999] fixed left-32 top-4">
+      <UBreadcrumb
+        :links="[{ label: 'Introduction', to: '/introduction' }, { label: 'Profile' }]"
+      >
+        <template #default="{ link, isActive }">
+          <UBadge
+            :color="isActive ? 'primary' : 'gray'"
+            class="rounded-full truncate"
+          >
+            {{ link.label }}
+          </UBadge>
+        </template>
+      </UBreadcrumb>
+    </div>
     <form
       class="flex flex-col gap-4 w-1/4"
       @submit.prevent="updateProfile"

--- a/faverton-nuxt3/app/pages/introduction/[slug].vue
+++ b/faverton-nuxt3/app/pages/introduction/[slug].vue
@@ -41,6 +41,20 @@ const article = articles.find(a => a.articlesId === slug);
 <template>
   <div>
     <AppHeader />
+    <div class="z-index-[999] absolute left-32 top-4">
+      <UBreadcrumb
+        :links="[{ label: 'Introduction', to: '/introduction' }, { label: article.title }]"
+      >
+        <template #default="{ link, isActive }">
+          <UBadge
+            :color="isActive ? 'primary' : 'gray'"
+            class="rounded-full truncate"
+          >
+            {{ link.label }}
+          </UBadge>
+        </template>
+      </UBreadcrumb>
+    </div>
     <div class="bg-[url('../Ventilateurs.jpg')] bg-cover flex flex-col justify-center h-screen">
       <div
         ref="titleSection1"

--- a/faverton-nuxt3/app/pages/introduction/index.client.vue
+++ b/faverton-nuxt3/app/pages/introduction/index.client.vue
@@ -46,6 +46,20 @@ onUnmounted(() => {
         </template>
       </ClientOnly>
       <div class="flex justify-end w-full ">
+        <div class="z-index-[999] absolute left-32 top-4">
+          <UBreadcrumb
+            :links="[{ label: 'Introduction' }]"
+          >
+            <template #default="{ link, isActive }">
+              <UBadge
+                :color="isActive ? 'primary' : 'gray'"
+                class="rounded-full truncate"
+              >
+                {{ link.label }}
+              </UBadge>
+            </template>
+          </UBreadcrumb>
+        </div>
         <div class="flex justify-center lg:w-[93.75%] xl:w-[95%]">
           <div class="text-white flex flex-col items-center gap-3 h-screen md:gap-3 w-[40%] sm:w-[47%] lg:w-[47%] xl:w-[55%]">
             <div class="mt-20 flex justify-center w-[35%] sm:mt-[5%] sm:w-[20%] lg:w-[20%] xl:w-[20%]">

--- a/faverton-nuxt3/app/pages/login/index.vue
+++ b/faverton-nuxt3/app/pages/login/index.vue
@@ -26,6 +26,20 @@ const gotToRegister = () => {
 
 <template>
   <UContainer class="h-screen flex flex-col justify-center items-center">
+    <div class="z-index-[999] fixed left-32 top-4">
+      <UBreadcrumb
+        :links="[{ label: 'Introduction', to: '/introduction' }, { label: 'Se connecter' }]"
+      >
+        <template #default="{ link, isActive }">
+          <UBadge
+            :color="isActive ? 'primary' : 'gray'"
+            class="rounded-full truncate"
+          >
+            {{ link.label }}
+          </UBadge>
+        </template>
+      </UBreadcrumb>
+    </div>
     <div>
       <h1 class=" h-10">
         Se connecter

--- a/faverton-nuxt3/app/pages/simulator/index.vue
+++ b/faverton-nuxt3/app/pages/simulator/index.vue
@@ -37,6 +37,20 @@ watch(jrcResponse, (newJrc) => {
 
 <template>
   <div>
+    <div class="z-[9000] fixed top-2 left-5">
+      <UBreadcrumb
+        :links="[{ label: 'Introduction', to: '/introduction' }, { label: 'Simulator' }]"
+      >
+        <template #default="{ link, isActive }">
+          <UBadge
+            :color="isActive ? 'primary' : 'gray'"
+            class="rounded-full truncate"
+          >
+            {{ link.label }}
+          </UBadge>
+        </template>
+      </UBreadcrumb>
+    </div>
     <FavertonCard>
       <h1 class="text-xl text-center p-6 text-white">
         Étapes de l'estimation


### PR DESCRIPTION
This pull request introduces breadcrumb navigation to several pages in the `faverton-nuxt3` application, enhancing the user experience by providing clear navigational context. Breadcrumbs are added to login, registration, profile, introduction, and simulator pages, with consistent styling and positioning.

### Breadcrumb Navigation Additions:

* **Login and Registration Pages**: Added breadcrumbs to `UserAuthLogin.vue` and `UserAuthRegister.vue` to display navigation paths like "Introduction > Se connecter" or "Introduction > Crée un compte." (`[[1]](diffhunk://#diff-c34301cc5a494413de6387dea621ff45ec0fee36c6d4fe6d297108e8dcbbeba7R27-R41)`, `[[2]](diffhunk://#diff-098171c5c5c1c79d6ccec5ed9985714d279b927a17443dcb75b77882cd2140abR40-R53)`)
* **Profile Page**: Introduced breadcrumbs in `UserProfile.vue` to show navigation paths such as "Introduction > Profile." (`[faverton-nuxt3/app/components/user/profile/UserProfile.vueR86-R99](diffhunk://#diff-c209e561b9d3b9f8dffd4b9b36ecee9ee833fddadadfc2b5021f10d584ebbb08R86-R99)`)
* **Introduction Pages**: 
  - Added breadcrumbs to the main introduction page (`index.client.vue`) with a single "Introduction" label. (`[faverton-nuxt3/app/pages/introduction/index.client.vueR49-R62](diffhunk://#diff-ff010ea591924b047890c19c2c46fe1e2bb76dcadc010b0e74ce5efbec1edea2R49-R62)`)
  - Enhanced individual article pages (`[slug].vue`) with dynamic breadcrumbs showing the article title. (`[faverton-nuxt3/app/pages/introduction/[slug].vueR44-R57](diffhunk://#diff-26429c2440c4e71fd9de7e3bd5a73cfceafacf4b3e826e3ba803e063e982d156R44-R57)`)
* **Simulator Page**: Implemented breadcrumbs in `simulator/index.vue` to guide users with paths like "Introduction > Simulator." (`[faverton-nuxt3/app/pages/simulator/index.vueR40-R53](diffhunk://#diff-a88d35e1925f35744227d688310105716c37d5af0094e4530e7aef744e891164R40-R53)`)