### PR TITLE
Fix(84): adresse - search panel selection and map rendering

### DIFF
--- a/faverton-nuxt3/app/components/faverton/map/FavertonMap.client.vue
+++ b/faverton-nuxt3/app/components/faverton/map/FavertonMap.client.vue
@@ -160,20 +160,15 @@ watch(() => mapStore.activateDrawing, (activate) => {
     />
     <LControlLayers position="bottomright" />
     <LControlZoom position="topright" />
-    <LCircle
-      v-if="featureCollection?.features[0]?.geometry?.coordinates"
-      :lat-lng="getCoordinates(featureCollection)"
-      :radius="500"
-      :options="{
-        color: '#3388ff',
-        fillColor: '#3388ff',
-        fillOpacity: 0.2,
-        weight: 2,
-      }"
-    >
-      <LPopup>
-        Code postal: {{ featureCollection?.features[0]?.properties?.postcode }}
-      </LPopup>
-    </LCircle>
+    <LLayerGroup v-if="featureCollection">
+      <LMarker :lat-lng="getCoordinates(featureCollection)">
+        <LPopup>
+          {{ addressStore.savedAddress?.name || 'Adresse sélectionnée' }}
+          <p>
+            Coordonnées: {{ getCoordinates(featureCollection) }}
+          </p>
+        </LPopup>
+      </LMarker>
+    </LLayerGroup>
   </LMap>
 </template>

--- a/faverton-nuxt3/server/api/address.ts
+++ b/faverton-nuxt3/server/api/address.ts
@@ -1,18 +1,21 @@
 export default defineEventHandler(async (event) => {
   const query = getQuery(event);
   const address = query.q as string;
-  const url = `https://api-adresse.data.gouv.fr/search`;
+  const url = `https://data.geopf.fr/geocodage/search`;
+  // NOTE: api version
+  // https://data.geopf.fr/geocodage/search (la nouvelle)
+  // https://api-adresse.data.gouv.fr/search (l'ancien)
 
   if (!address) {
     return [];
   }
 
-  if (address.length <= 2) {
+  if (address.length < 4) {
     return [];
   }
 
   const response = await $fetch(url, {
-    query: { q: encodeURIComponent(address as string), limit: 5 },
+    query: { q: address, limit: 7, autocomplete: 1 },
   });
   return response;
 });


### PR DESCRIPTION
This pull request introduces several updates to improve the handling of address search, panel selection, and map rendering in the Faverton application. The most significant changes include refactoring the address search component to use a new API and stricter type definitions, enhancing the panel selection menu with better search capabilities, and updating the map display to replace circles with markers for selected addresses.

### Address Search Improvements:
* Refactored `FavertonInputSearch.vue` to use the new `NewFeatureCollection` type and stricter typing for `AddressOption`. Added client-side-only fetching (`server: false`) and improved the computed `proposition` function to handle empty results safely. (`[[1]](diffhunk://#diff-08f4a4b9e54f33da88118c76ba3a96a50aa57c19957fb31537940c717647ec46L6-R28)`, `[[2]](diffhunk://#diff-08f4a4b9e54f33da88118c76ba3a96a50aa57c19957fb31537940c717647ec46R38-R62)`)
* Updated the `onSelect` function to handle `AddressOption` objects, ensuring consistent data structure and emitting the correct model value. (`[faverton-nuxt3/app/components/faverton/input/search/FavertonInputSearch.vueR75](diffhunk://#diff-08f4a4b9e54f33da88118c76ba3a96a50aa57c19957fb31537940c717647ec46R75)`)
* Switched the address search API from `api-adresse.data.gouv.fr` to `data.geopf.fr` with updated query parameters for improved results. (`[faverton-nuxt3/server/api/address.tsL4-R18](diffhunk://#diff-d4170cd884e32d1659b7eb56432f8ae671f8cc9674e2008a789faac1dd7213b4L4-R18)`)

### Map Rendering Enhancements:
* Replaced `LCircle` with `LMarker` and `LLayerGroup` in `FavertonMap.client.vue` for better visualization of selected addresses. Added a popup to display the address name and coordinates. (`[faverton-nuxt3/app/components/faverton/map/FavertonMap.client.vueL163-R172](diffhunk://#diff-65f6c4414859c02ccd65cf9f320f77e2417ae20effd3b6570364041e3bc4c432L163-R172)`)

### Panel Selection Improvements:
* Enhanced `FavertonSelectMenu.vue` by adding a `displayLabel` for panels and enabling search by multiple attributes (`model` and `efficiency`). Updated the `watch` logic to handle panel selection more robustly. (`[[1]](diffhunk://#diff-544651abc13a3ee594d4f02157962c0d2abb5e3ba6ad1e1617ec750047891424L6-R29)`, `[[2]](diffhunk://#diff-544651abc13a3ee594d4f02157962c0d2abb5e3ba6ad1e1617ec750047891424L32-R40)`)