### PR TITLE
feat(88): simulation test - fields to be filled in by user

### DIFF
--- a/.github/instructions/prompt.instructions.md
+++ b/.github/instructions/prompt.instructions.md
@@ -1,0 +1,4 @@
+---
+applyTo: '**'
+---
+ Prendre en compte dans ta réponse: Concentre-toi sur le fond plutôt que sur les compliments. Évitez les compliments inutiles ou les éloges qui manquent de profondeur. Engage-toi de manière critique dans mes idées, remettez en question les hypothèses, identifiez les préjugés et proposez des contre-arguments lorsque cela est pertinent. N'hésitez pas à exprimer ton désaccord lorsque cela est justifié et assure-toi que tout accord repose sur la raison et des preuves

--- a/.github/instructions/stubs-and-shallow-mount.instructions.md
+++ b/.github/instructions/stubs-and-shallow-mount.instructions.md
@@ -1,0 +1,430 @@
+---
+applyTo: '**'
+---
+
+# Stubs and Shallow Mount[​](https://test-utils.vuejs.org/guide/advanced/stubs-shallow-mount.html#Stubs-and-Shallow-Mount)
+ 
+Vue Test Utils provides some advanced features for _stubbing_ components and directives. A _stub_ is where you replace an existing implementation of a custom component or directive with a dummy one that doesn't do anything at all, which can simplify an otherwise complex test. Let's see an example.
+
+## Stubbing a single child component[​](https://test-utils.vuejs.org/guide/advanced/stubs-shallow-mount.html#Stubbing-a-single-child-component)
+
+A common example is when you would like to test something in a component that appears very high in the component hierarchy.
+
+In this example, we have an `<App>` that renders a message, as well as a `FetchDataFromApi` component that makes an API call and renders its result.
+
+js
+
+```
+const FetchDataFromApi = {
+  name: 'FetchDataFromApi',
+  template: `
+    <div>{{ result }}</div>
+  `,
+  async mounted() {
+    const res = await axios.get('/api/info')
+    this.result = res.data
+  },
+  data() {
+    return {
+      result: ''
+    }
+  }
+}
+
+const App = {
+  components: {
+    FetchDataFromApi
+  },
+  template: `
+    <h1>Welcome to Vue.js 3</h1>
+    <fetch-data-from-api />
+  `
+}
+```
+
+We do not want to make the API call in this particular test, we just want to assert the message is rendered. In this case, we could use the `stubs`, which appears in the `global` mounting option.
+
+js
+
+```
+test('stubs component with custom template', () => {
+  const wrapper = mount(App, {
+    global: {
+      stubs: {
+        FetchDataFromApi: {
+          template: '<span />'
+        }
+      }
+    }
+  })
+
+  console.log(wrapper.html())
+  // <h1>Welcome to Vue.js 3</h1><span></span>
+
+  expect(wrapper.html()).toContain('Welcome to Vue.js 3')
+})
+```
+
+Notice that the template is showing `<span></span>` where `<fetch-data-from-api />` was? We replaced it with a stub - in this case, we provided our own implementation by passing in a `template`.
+
+You can also get a default stub, instead of providing your own:
+
+js
+
+```
+test('stubs component', () => {
+  const wrapper = mount(App, {
+    global: {
+      stubs: {
+        FetchDataFromApi: true
+      }
+    }
+  })
+
+  console.log(wrapper.html())
+  /*
+    <h1>Welcome to Vue.js 3</h1>
+    <fetch-data-from-api-stub></fetch-data-from-api-stub>
+  */
+
+  expect(wrapper.html()).toContain('Welcome to Vue.js 3')
+})
+```
+
+This will stub out _all_ the `<FetchDataFromApi />` components in the entire render tree, regardless of what level they appear at. That's why it is in the `global` mounting option.
+
+TIP
+
+To stub out you can either use the key in `components` or the name of your component. If both are given in `global.stubs` the key will be used first.
+
+## Stubbing all children components[​](https://test-utils.vuejs.org/guide/advanced/stubs-shallow-mount.html#Stubbing-all-children-components)
+
+Sometimes you might want to stub out _all_ the custom components. For example you might have a component like this:
+
+js
+
+```
+const ComplexComponent = {
+  components: { ComplexA, ComplexB, ComplexC },
+  template: `
+    <h1>Welcome to Vue.js 3</h1>
+    <ComplexA />
+    <ComplexB />
+    <ComplexC />
+  `
+}
+```
+
+Imagine each of the `<Complex>` does something complicated, and you are only interested in testing that the `<h1>` is rendering the correct greeting. You could do something like:
+
+js
+
+```
+const wrapper = mount(ComplexComponent, {
+  global: {
+    stubs: {
+      ComplexA: true,
+      ComplexB: true,
+      ComplexC: true
+    }
+  }
+})
+```
+
+But that's a lot of boilerplate. VTU has a `shallow` mounting option that will automatically stub out all the child components:
+
+js
+
+```
+test('shallow stubs out all child components', () => {
+  const wrapper = mount(ComplexComponent, {
+    shallow: true
+  })
+
+  console.log(wrapper.html())
+  /*
+    <h1>Welcome to Vue.js 3</h1>
+    <complex-a-stub></complex-a-stub>
+    <complex-b-stub></complex-b-stub>
+    <complex-c-stub></complex-c-stub>
+  */
+})
+```
+
+TIP
+
+If you used VTU V1, you may remember this as `shallowMount`. That method is still available, too - it's the same as writing `shallow: true`.
+
+## Stubbing all children components with exceptions[​](https://test-utils.vuejs.org/guide/advanced/stubs-shallow-mount.html#Stubbing-all-children-components-with-exceptions)
+
+Sometimes you want to stub out _all_ the custom components, _except_ specific one. Let's consider an example:
+
+js
+
+```
+const ComplexA = {
+  template: '<h2>Hello from real component!</h2>'
+}
+
+const ComplexComponent = {
+  components: { ComplexA, ComplexB, ComplexC },
+  template: `
+    <h1>Welcome to Vue.js 3</h1>
+    <ComplexA />
+    <ComplexB />
+    <ComplexC />
+  `
+}
+```
+
+By using `shallow` mounting option that will automatically stub out all the child components. If we want to explicitly opt-out of stubbing specific component, we could provide its name in `stubs` with value set to `false`
+
+js
+
+```
+test('shallow allows opt-out of stubbing specific component', () => {
+  const wrapper = mount(ComplexComponent, {
+    shallow: true,
+    global: {
+      stubs: { ComplexA: false }
+    }
+  })
+
+  console.log(wrapper.html())
+  /*
+    <h1>Welcome to Vue.js 3</h1>
+    <h2>Hello from real component!</h2>
+    <complex-b-stub></complex-b-stub>
+    <complex-c-stub></complex-c-stub>
+  */
+})
+```
+
+## Stubbing an async component[​](https://test-utils.vuejs.org/guide/advanced/stubs-shallow-mount.html#Stubbing-an-async-component)
+
+In case you want to stub out an async component, then there are two behaviours. For example, you might have components like this:
+
+js
+
+```
+// AsyncComponent.js
+export default defineComponent({
+  name: 'AsyncComponent',
+  template: '<span>AsyncComponent</span>'
+})
+
+// App.js
+const App = defineComponent({
+  components: {
+    MyComponent: defineAsyncComponent(() => import('./AsyncComponent'))
+  },
+  template: '<MyComponent/>'
+})
+```
+
+The first behaviour is using the key defined in your component which loads the async component. In this example we used to key "MyComponent". It is not required to use `async/await` in the test case, because the component has been stubbed out before resolving.
+
+js
+
+```
+test('stubs async component without resolving', () => {
+  const wrapper = mount(App, {
+    global: {
+      stubs: {
+        MyComponent: true
+      }
+    }
+  })
+
+  expect(wrapper.html()).toBe('<my-component-stub></my-component-stub>')
+})
+```
+
+The second behaviour is using the name of the async component. In this example we used to name "AsyncComponent". Now it is required to use `async/await`, because the async component needs to be resolved and then can be stubbed out by the name defined in the async component.
+
+**Make sure you define a name in your async component!**
+
+js
+
+```
+test('stubs async component with resolving', async () => {
+  const wrapper = mount(App, {
+    global: {
+      stubs: {
+        AsyncComponent: true
+      }
+    }
+  })
+
+  await flushPromises()
+
+  expect(wrapper.html()).toBe('<async-component-stub></async-component-stub>')
+})
+```
+
+## Stubbing a directive[​](https://test-utils.vuejs.org/guide/advanced/stubs-shallow-mount.html#Stubbing-a-directive)
+
+Sometimes directives do quite complex things, like perform a lot of DOM manipulation which might result in errors in your tests (due to JSDOM not resembling entire DOM behavior). A common example is tooltip directives from various libraries, which usually rely heavily on measuring DOM nodes position/sizes.
+
+In this example, we have another `<App>` that renders a message with tooltip
+
+js
+
+```
+// tooltip directive declared somewhere, named `Tooltip`
+
+const App = {
+  directives: {
+    Tooltip
+  },
+  template: '<h1 v-tooltip title="Welcome tooltip">Welcome to Vue.js 3</h1>'
+}
+```
+
+We do not want the `Tooltip` directive code to be executed in this test, we just want to assert the message is rendered. In this case, we could use the `stubs`, which appears in the `global` mounting option passing `vTooltip`.
+
+js
+
+```
+test('stubs component with custom template', () => {
+  const wrapper = mount(App, {
+    global: {
+      stubs: {
+        vTooltip: true
+      }
+    }
+  })
+
+  console.log(wrapper.html())
+  // <h1>Welcome to Vue.js 3</h1>
+
+  expect(wrapper.html()).toContain('Welcome to Vue.js 3')
+})
+```
+
+TIP
+
+Usage of `vCustomDirective` naming scheme to differentiate between components and directives is inspired by [same approach](https://vuejs.org/api/sfc-script-setup.html#using-custom-directives) used in `<script setup>`
+
+Sometimes, we need a part of directive functionality (usually because some code relies on it). Let's assume our directive adds `with-tooltip` CSS class when executed and this is important behavior for our code. In this case we can swap `true` with our mock directive implementation
+
+js
+
+```
+test('stubs component with custom template', () => {
+  const wrapper = mount(App, {
+    global: {
+      stubs: {
+        vTooltip: {
+          beforeMount(el: Element) {
+            console.log('directive called')
+            el.classList.add('with-tooltip')
+          }
+        }
+      }
+    }
+  })
+
+  // 'directive called' logged to console
+
+  console.log(wrapper.html())
+  // <h1 class="with-tooltip">Welcome to Vue.js 3</h1>
+
+  expect(wrapper.classes('with-tooltip')).toBe(true)
+})
+```
+
+We've just swapped our directive implementation with our own one!
+
+WARNING
+
+Stubbing directives won't work on functional components or `<script setup>` due to lack of directive name inside of [withDirectives](https://vuejs.org/api/render-function.html#withdirectives) function. Consider mocking directive module via your testing framework if you need to mock directive used in functional component. See [https://github.com/vuejs/core/issues/6887](https://github.com/vuejs/core/issues/6887) for proposal to unlock such functionality
+
+## Default Slots and `shallow`[​](https://test-utils.vuejs.org/guide/advanced/stubs-shallow-mount.html#Default-Slots-and-shallow)
+
+Since `shallow` stubs out all the content of a components, any `<slot>` won't get rendered when using `shallow`. While this is not a problem in most cases, there are some scenarios where this isn't ideal.
+
+js
+
+```
+const CustomButton = {
+  template: `
+    <button>
+      <slot />
+    </button>
+  `
+}
+```
+
+And you might use it like this:
+
+js
+
+```
+const App = {
+  props: ['authenticated'],
+  components: { CustomButton },
+  template: `
+    <custom-button>
+      <div v-if="authenticated">Log out</div>
+      <div v-else>Log in</div>
+    </custom-button>
+  `
+}
+```
+
+If you are using `shallow`, the slot will not be rendered, since the render function in `<custom-button />` is stubbed out. That means you won't be able to verify the correct text is rendered!
+
+For this use case, you can use `config.renderStubDefaultSlot`, which will render the default slot content, even when using `shallow`:
+
+js
+
+```
+import { config, mount } from '@vue/test-utils'
+
+beforeAll(() => {
+  config.global.renderStubDefaultSlot = true
+})
+
+afterAll(() => {
+  config.global.renderStubDefaultSlot = false
+})
+
+test('shallow with stubs', () => {
+  const wrapper = mount(AnotherApp, {
+    props: {
+      authenticated: true
+    },
+    shallow: true
+  })
+
+  expect(wrapper.html()).toContain('Log out')
+})
+```
+
+Since this behavior is global, not on a `mount` by `mount` basis, you need to remember to enable/disable it before and after each test.
+
+TIP
+
+You can also enable this globally by importing `config` in your test setup file, and setting `renderStubDefaultSlot` to `true`. Unfortunately, due to technical limitations, this behavior is not extended to slots other than the default slot.
+
+## `mount`, `shallow` and `stubs`: which one and when?[​](https://test-utils.vuejs.org/guide/advanced/stubs-shallow-mount.html#mount-shallow-and-stubs-which-one-and-when-)
+
+As a rule of thumb, **the more your tests resemble the way your software is used**, the more confidence they can give you.
+
+Tests that use `mount` will render the entire component hierarchy, which is closer to what the user will experience in a real browser.
+
+On the other hand, tests using `shallow` are focused on a specific component. `shallow` can be useful for testing advanced components in complete isolation. If you just have one or two components that are not relevant to your tests, consider using `mount` in combination with `stubs` instead of `shallow`. The more you stub, the less production-like your test becomes.
+
+Keep in mind that whether you are doing a full mount or a shallow render, good tests focus on inputs (`props` and user interaction, such as with `trigger`) and outputs (the DOM elements that are rendered, and events), not implementation details.
+
+So regardless of which mounting method you choose, we suggest keeping these guidelines in mind.
+
+## Conclusion[​](https://test-utils.vuejs.org/guide/advanced/stubs-shallow-mount.html#Conclusion)
+
+- use `global.stubs` to replace a component or directive with a dummy one to simplify your tests
+- use `shallow: true` (or `shallowMount`) to stub out all child components
+- use `global.renderStubDefaultSlot` to render the default `<slot>` for a stubbed component
+
+[  
+](https://github.com/vuejs/test-utils/edit/main/docs/guide/advanced/stubs-shallow-mount.md)

--- a/.github/instructions/test-god-pratique.instructions.md
+++ b/.github/instructions/test-god-pratique.instructions.md
@@ -310,7 +310,7 @@ C'est pourquoi vous pouvez écrire [expect(mockSignIn).toHaveBeenCalledWith(...
 ---
 ## Handling events
 
-- `vm.$emit()` always followed by a $nextTick()
+- `vm.$emit()` always followed by a nextTick()
 - `trigger()` always awaited
 
 ```ts
@@ -325,8 +325,8 @@ describe(`Test page`, () => {
     const inputComponent = wrapper.findComponent(UInput);
     expect(inputComponent.exists()).toBe(true);
     inputComponent.vm.$emit(`update:modelValue`, `my input value`);
-    // mandatory `await wrapper.vm.$nextTick();`
-    await wrapper.vm.$nextTick();
+    // mandatory `await nextTick();`
+    await nextTick();
     const button = wrapper.find(`button`);
     expect(button.exists()).toBe(true);
     // mandatory `await` before trigger
@@ -375,7 +375,7 @@ it(`can delete a property`, async (context) => {
   const confirmBtn = wrapper.findAllComponents(UButton).at(-1);
   context.mockDelete(PROPERTY_API_URL);
   confirmBtn?.vm.$emit(`click`);
-  await wrapper.vm.$nextTick();
+  await nextTick();
   // so we need to “find” again to be update-to-date with the DOM
   expect(wrapper.findAllComponents(UButton).at(-1)?.props(`loading`)).toBe(true);
   await flushPromises();
@@ -678,7 +678,7 @@ test(`update success`, async (context) => {
   const wrapper = shallowMount(ValuationFileCard);
   await context.flushPromises();
   wrapper.findComponent(UButton).vm.$emit(`files`, FILES);
-  await wrapper.vm.$nextTick();
+  await nextTick();
   // first requests
   context.mockPost(VALUATION_API_URL, { data: FILE_UPLOADED });
   context.mockPut(PROPERTY_API_URL, { data: propertyResponseWithValuation });

--- a/.github/instructions/test-god-pratique.instructions.md
+++ b/.github/instructions/test-god-pratique.instructions.md
@@ -1,0 +1,753 @@
+---
+applyTo: '**'
+---
+
+## Config
+test e2e dans `playwright.config.ts`
+```TS
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: `./app/tests/e2e`,
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: `html`,
+  use: {
+    baseURL: `http://localhost:3000`,
+    trace: `on-first-retry`,
+  },
+  projects: [
+    {
+      name: `chromium`,
+      use: { ...devices[`Desktop Chrome`] },
+    },
+  ],
+  webServer: {
+    command: `pnpm run dev`,
+    url: `http://localhost:3000`,
+    reuseExistingServer: !process.env.CI,
+  },
+});
+```
+
+Ajoute des scripts pour exécuter les tests :
+```json
+"scripts": {
+  "test:unit": "vitest tests/unit/",
+  "test:e2e": "vitest tests/e2e/",
+  "test:all": "vitest"
+}
+```
+
+# Commands
+
+```Shell
+# run once
+pnpm test:unit
+
+# watch mode
+pnpm test
+
+# 🔁 Exécution des tests d'intégration (sans mode watch)
+pnpm test:integration
+
+# 🧪 Tests end-to-end (E2E) avec Playwright
+pnpm test:e2e
+
+# 🐞 Tests E2E avec mode débogage (pas-à-pas, breakpoints, console visible)
+pnpm test:e2e:debug
+
+# 👁️ Interface interactive de Playwright pour lancer les tests E2E manuellement
+pnpm test:e2e:ui
+
+# 📊 Affiche le rapport HTML des tests E2E déjà exécutés
+pnpm test:e2e:report
+
+# 🧹 Nettoyage des résultats de tests E2E et des rapports générés
+pnpm test:e2e:clean
+
+# 🧹 Nettoyage des fichiers E2E générés depuis Git (utile si ajoutés par erreur)
+pnpm test:e2e:clean-git
+
+# ✅ Vérifications complètes avant CI :
+#   - tests unitaires
+#   - tests d'intégration
+#   - tests end-to-end
+pnpm test:all
+```
+
+## Arborescence
+
+```shell
+app/
+├── pages/
+│   ├── user/
+│   │   ├── page.vue
+│   │   ├── page.test.ts        ← ✅ Test unitaire de la page
+├── components/
+│   ├── UserAuthLogin.vue
+│   ├── UserAuthLogin.test.ts    ← ✅ Test du composant
+└── tests/
+    ├── e2e/
+    │   ├── __mocks__/
+    │   │   ├── auth/
+    │   │   │   ├── users-valid.json
+    │   │   │   ├── users-invalid.json
+    │   │   │   └── auth-responses.json
+    │   │   └── supabase/
+    │   │       └── auth-client.json
+    │   ├── user/
+    │   │   ├── login.e2e.spec.ts  ← ✅ Test de bout en bout
+```
+
+## Pourquoi séparer vitest/Playwright ?
+
+1. **Outils différents** : [Playwright](https://playwright.dev/docs) et Vitest sont des outils distincts avec des configurations spécifiques
+2. **Types de tests différents** :
+    - Vitest → tests unitaires/intégration
+    - Playwright → tests e2e
+3. **Environnements différents** : Configurations et dépendances distinctes
+
+
+---
+
+Voici la **traduction critique et adaptée** de cette section, avec des ajustements pour l’intégrer dans un projet Nuxt 3 utilisant **Nuxt UI** (donc avec un composant comme `UInput` à la place de `IadDataTable`) :
+
+---
+
+## 🧪 Tester des composants
+
+---
+
+## ✍️ Exemple de test simple de composant
+
+Dans un fichier `./components.test.ts` :
+
+```ts
+import { shallowMount } from '@vue/test-utils'
+import TestPage from './test.vue'
+
+describe('TestPage', () => {
+  test('rendu basique', () => {
+    const wrapper = shallowMount(TestPage)
+    expect(wrapper.find('div').exists()).toBe(true)
+  })
+})
+```
+
+---
+
+## 🧩 Tester les slots nommés
+
+Il arrive que l’on veuille tester le contenu d’un **slot nommé**.  
+Or, `shallowMount` **ne rend pas** les slots enfants par défaut.  
+Il faut alors **désactiver le stub** pour certains composants précis.
+
+Par exemple, ici on veut tester un `UInput` avec un slot personnalisé :
+
+```ts
+import { shallowMount } from '@vue/test-utils'
+
+describe('TestPage', () => {
+  test('rendu du slot de UInput', () => {
+    const wrapper = shallowMount(TestPage, {
+      global: {
+        // on rend complètement UInput au lieu de le stubber
+        //// shallowMount everything BUT fully render IadDataTable
+        stubs: { UInput: false }
+      }
+    })
+
+    // Exemple de vérification du contenu injecté dans un slot
+    expect(wrapper.find('input').exists()).toBe(true)
+    expect(wrapper.find('input').attributes('placeholder')).toBe('Entrer une valeur')
+  })
+})
+```
+
+
+---
+## Qu'est-ce qu'un Spy (Espion) ?
+
+Un **spy** est un outil de test qui remplace une fonction existante pour :
+
+1. **Enregistrer** tous les appels (arguments, nombre d'appels, etc.)
+2. **Contrôler** ce que la fonction retourne
+3. **Vérifier** comment elle a été utilisée
+## Métaphore Simple
+
+```ts
+Vraie méthode = Employé normal qui fait son travail
+Spy = Employé remplaçant qui :
+  ✓ Fait le travail demandé (retourne une valeur contrôlée)
+  ✓ Note tout dans un carnet (qui a appelé, avec quels arguments)
+```
+
+## Exemple Pratique
+
+1. Création du Spy
+```ts
+// Remplace la vraie méthode par un spy
+const mockSignIn = vi.spyOn(vm.supabase.auth, 'signInWithPassword')
+  .mockResolvedValue({ error: null });
+```
+
+2. Ce que le Spy Enregistre Automatiquement
+```ts
+// Le spy crée automatiquement un "carnet" avec :
+mockSignIn.mock = {
+  calls: [],           // Tous les appels avec leurs arguments
+  instances: [],       // Contexte des appels
+  invocationCallOrder: [], // Ordre des appels
+  results: []          // Résultats retournés
+}
+```
+
+3. Quand le Composant Appelle la Méthode
+```ts
+<!-- Dans le composant -->
+await supabase.auth.signInWithPassword({
+  email: "valid@email.com",
+  password: "correctpassword"
+});
+```
+
+**Le spy enregistre automatiquement :**
+```ts
+mockSignIn.mock.calls[0] = [{
+  email: "valid@email.com",
+  password: "correctpassword"
+}];
+```
+
+## Vérifications Possibles avec les Spies
+
+Vérifier les Arguments Exacts
+```ts
+expect(mockSignIn).toHaveBeenCalledWith({
+  email: "valid@email.com",
+  password: "correctpassword",
+});
+```
+
+Vérifier le Nombre d'Appels
+```ts
+expect(mockSignIn).toHaveBeenCalledTimes(1);
+```
+
+Vérifier qu'il a été Appelé
+```ts
+expect(mockSignIn).toHaveBeenCalled();
+```
+
+Vérifier qu'il N'a PAS été Appelé
+```ts
+expect(mockSignIn).not.toHaveBeenCalled();
+```
+
+Accéder aux Arguments Directement
+```ts
+expect(mockSignIn.mock.calls[0][0].email).toBe("valid@email.com");
+```
+
+## Différence : Spy vs Fonction Normale
+### Sans Spy ❌
+```ts
+const normalFunction = () => { return { error: null }; };
+// ❌ Impossible de savoir si elle a été appelée
+// ❌ Impossible de connaître les arguments
+```
+### Avec Spy ✅
+```ts
+const spy = vi.spyOn(obj, 'method').mockResolvedValue({ error: null });
+// ✓ Sait tout sur ses appels
+// ✓ Peut vérifier les arguments
+// ✓ Peut compter les appels
+```
+
+## Exemple Complet de Test
+```ts
+test('redirige vers /simulator en cas de succès', async () => {
+  const wrapper = shallowMount(UserAuthLogin);
+  const vm = wrapper.vm as any;
+
+  // 1. Créer le spy
+  const mockSignIn = vi.spyOn(vm.supabase.auth, 'signInWithPassword')
+    .mockResolvedValue({ error: null });
+
+  // 2. Configurer les données
+  vm.email = 'valid@email.com';
+  vm.password = 'correctpassword';
+
+  // 3. Exécuter l'action
+  await vm.login();
+  await flushPromises();
+
+  // 4. Vérifier que le spy a été appelé correctement
+  expect(mockSignIn).toHaveBeenCalledWith({
+    email: 'valid@email.com',
+    password: 'correctpassword',
+  });
+
+  // 5. Vérifier le comportement du composant
+  expect(vm.error).toBe('');
+  expect(vm.message).toBe('Connexion réussie');
+});
+```
+
+## Résumé
+
+Un spy vous donne **deux pouvoirs** :
+
+1. **Contrôler** ce que la méthode retourne (`.mockResolvedValue()`)
+2. **Vérifier** comment elle a été utilisée (`.toHaveBeenCalledWith()`)
+
+C'est pourquoi vous pouvez écrire [expect(mockSignIn).toHaveBeenCalledWith(...)](vscode-file://vscode-app/snap/code/194/usr/share/code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) - le spy a **automatiquement enregistré** tous les détails de l'appel !
+
+
+---
+## Handling events
+
+- `vm.$emit()` always followed by a $nextTick()
+- `trigger()` always awaited
+
+```ts
+import { shallowMount } from '@vue/test-utils';
+
+import TestPage from './test.vue';
+
+describe(`Test page`, () => {
+  test(`rendering`, async () => {
+    expect(TestPage).toBeTruthy();
+    const wrapper = shallowMount(TestPage);
+    const inputComponent = wrapper.findComponent(UInput);
+    expect(inputComponent.exists()).toBe(true);
+    inputComponent.vm.$emit(`update:modelValue`, `my input value`);
+    // mandatory `await wrapper.vm.$nextTick();`
+    await wrapper.vm.$nextTick();
+    const button = wrapper.find(`button`);
+    expect(button.exists()).toBe(true);
+    // mandatory `await` before trigger
+    await button.trigger(`click`);
+    // … rest of the test
+  });
+});
+```
+
+## Handling defineModels
+
+`defineModel` act as a `ref` is the expected props isn't passed.
+
+This will work:
+
+```ts
+it(`should close the popup on button click`, async () => {
+  const wrapper = shallowMount(DeleteModal, { props: { modelValue: true } } );
+  const dialog = wrapper.findComponent(UDialog);
+  await expect(wrapper.findComponent(UButton).trigger(`click`);
+  expect(wrapper.emitted(`update:modelValue`)).toEqual([[false]]);
+});
+```
+
+This will not:
+
+```ts
+it(`should close the popup on button click`, async () => {
+  // The “modelValue” isn't defined, defineModel will act a ref
+  const wrapper = shallowMount(DeleteModal);
+  const dialog = wrapper.findComponent(UModal);
+  await expect(wrapper.findComponent(UButton).trigger(`click`);
+  expect(wrapper.emitted(`update:modelValue`)).toBeUndefined();
+});
+```
+
+It seems that vue-test utils buttons references inside actions won't update
+
+```ts
+it(`can delete a property`, async (context) => {
+  const wrapper = shallowMount(DiscoveryListDeleteDialog, {
+    // Unstub dialog to be able to test “#actions” slot
+    global: { stubs: { UModal: false } },
+  });
+  // If we keep this reference and use it along the test, props won't be updated
+  const confirmBtn = wrapper.findAllComponents(UButton).at(-1);
+  context.mockDelete(PROPERTY_API_URL);
+  confirmBtn?.vm.$emit(`click`);
+  await wrapper.vm.$nextTick();
+  // so we need to “find” again to be update-to-date with the DOM
+  expect(wrapper.findAllComponents(UButton).at(-1)?.props(`loading`)).toBe(true);
+  await flushPromises();
+  // same here
+  expect(wrapper.findAllComponents(UButton).at(-1)?.props(`loading`)).toBe(false);
+});
+```
+
+---
+
+============================================================================================
+
+# Mocking Fetch requests 03-mock-fetch-requests
+
+We use [MSW](https://mswjs.io/) to fetch calls during tests (as advised by [Vitest](https://vitest.dev/guide/mocking.html#requests))
+
+The test `context` is enhanced with some utils:
+
+- `context.mockGet`
+- `context.mockPost`
+- `context.mockPatch`
+- `context.mockPut`
+- `context.mockDelete`
+
+:::danger Warning  
+Urls needs to be the same as what is queried, __search params included!__  
+you have the `searchParams` option to ease the writing of those  
+:::
+
+::: tip  
+Remember that you can debug fetch calls with:  
+```
+VITE_TEST__DEBUG_FETCH_MOCK=true VITE_TEST__DEBUG_FETCH_BODY=true pnpm test
+``` 
+
+see debugging the calls debugging-the-calls
+:::
+
+::: warning  
+Never make a single `ky().json()`  
+
+✅ Always write it that way for mock queries during tests to work
+
+```ts
+queryFn: async () => {
+  const req = await EndpointApi(`my-resource/${resourceId}`);
+  return req.json<ApiResource>()
+},
+```
+❌ The following won't fetch during tests
+
+```ts
+queryFn: async () => EndpointApi(`my-resource/${resourceId}`).json<ApiResource>()
+``` 
+:::
+
+## GET
+
+```ts
+it(`can fetch something`, async (context) => {
+  const data = { getTest: true };
+  // mock this GET route with those data
+  // it will be only possible to call it once
+  context.mockGet(`my-get-route`, { data });
+  // `ky` request is just provided as an example
+  // you will NEVER have to write this 
+  // see “In a component” section
+  const req = await ky(`http://localhost/my-get-route`);
+  const response = await req.json()
+  expect(response).toEqual(data);
+});
+```
+
+## GET with query params
+
+```ts
+it(`can fetch something`, async (context) => {
+  const data = { getTest: true };
+  // mock this GET route with those data
+  // Query params should match or the request will not be intercepted
+  context.mockGet(`my-get-route`, { data, searchParams: { page: 2 } });
+  // `ky` example (do not use in real application code)
+  const req = await ky(`http://localhost/my-get-route`, { searchParams: { page: 2 } });
+  const response = await req.json();
+  expect(response).toEqual(data);
+});
+```
+
+## GET with error
+
+```ts
+// GET with error
+it(`can fetch something`, async (context) => {
+  const data = { errorCode: 500, errorMessage: `something went wrong` };
+  // statusCode is the HTTP code
+  context.mockGet(`my-get-route`, { data, statusCode: 500 });
+  // `ky` example (do not use in real application code)
+  await expect(async () => {
+    const req = await ky(`http://localhost/my-get-route`)
+    return req.json()
+  }).rejects.toThrow(data);
+});
+```
+
+## GET with headers
+
+```ts
+it(`can fetch something`, async (context) => {
+  const data = { getTest: true };
+  context.mockGet(`my-get-route`, { data, statusCode: 401, responseHeaders: { 'X-SSO-SESSION-ERROR': `login_requested` } });
+  // `ky` example (do not use in real application code)
+  const { headers } = await ky(`http://localhost/my-get-route`, { searchParams: { page: 2 } });
+  expect(headers[`X-SSO-SESSION-ERROR`]).toBe(`login_requested`);
+});
+```
+
+## POST
+
+```ts
+it(`can post something`, async (context) => {
+  const data = { postTest: true };
+  context.mockPost(`my-post-route`, { data: { foo: true } });
+  // `ky` example (do not use in real application code)
+  const req = await ky.post(`http://localhost/my-post-route`, { json: { foo: true } });
+  const response = await req.json();
+  expect(response).toEqual(data);
+});
+```
+
+## Testing the JSON body
+
+You can trace either by:
+
+```
+VITE_TEST__DEBUG_FETCH_BODY=true pnpm test
+```
+
+or by adding into `.env.local`:  
+
+```
+VITE_TEST__DEBUG_FETCH_BODY=true
+```
+
+in your tests: 
+
+```ts
+test(`update success`, async (context) => {
+  const wrapper = shallowMount(AuthLogin);
+  await wrapper.findComponent(UModal).setValue(`bar`);
+  // This will return a `400` 
+  // when the json send to the API isn't the same as “expectedJson”
+  context.mockPut(PUT_API_URL, { expectedJson: { foo: `bar` } });
+  await wrapper.findComponent(UButton).trigger(`click`);
+  await context.flushPromises();
+  // …expects
+  expect(routerPushSpy).toHaveBeenCalled();
+});
+```
+## Testing the FormData body
+
+Same `env var` config applies as above
+
+```ts
+test(`update success`, async (context) => {
+  const wrapper = shallowMount(ValuationFileCard);
+  await wrapper.findComponent(UModal).setValue(`bar`);
+  // This will return a `400` 
+  // when the formData send to the API isn't the same as expectedFormData
+  const formData = new FormData()
+  formData.append(`foo`, `bar`);
+  context.mockPut(PUT_API_URL, { expectedFormData: formData });
+  await wrapper.findComponent(UButton).trigger(`click`);
+  await context.flushPromises();
+  // …expects
+  expect(routerPushSpy).toHaveBeenCalled();
+});
+```
+
+## Testing calls without side effects
+
+It may happens that a query is done without side effects:  
+no notifications, no redirection, etc.
+(ex: background update for something else)
+
+In that case your only remaining choice will be to check if the mocked request has been (or hasn't been) consumed.
+In the text context you will find the MSW server available `context.mockServer`
+
+
+```ts
+// Check if all requests has been consumed
+expect(context.mockServer.listHandlers().every(handler => handler.isUsed === true)).toBe(true);
+
+// Check that a specific request has been consumed
+expect(context.mockServer.listHandlers()[1].isUsed).toBe(false);
+
+// Check that some requests haven't been consumed
+expect(context.mockServer.listHandlers().every(handler => handler.isUsed === true)).toBe(false);
+```
+
+## In a component
+
+:::info   
+It is important to wait for the request to resolve  
+A rule of thumb will be:  
+**After each fetch, use `await flushPromises()`**
+:::
+
+
+```ts
+import { flushPromises, shallowMount } from '@vue/test-utils';
+
+it(`can fetch something`, async (context) => {
+  context.mockGet(`my-get-route`, { data: { getTest: true } });
+  // if the call is made on setup (ex: using a vue-query composable)
+  const wrapper = shallowMount(MyComponentWithApiCalls);
+  // wait for the request to be handled
+  await flushPromises();
+  expect(wrapper.html()).toMatchSnapshot();
+});
+```
+
+### If you have the same call on every group of test
+
+Useful if calls are made when initializing the component
+
+```ts
+import { flushPromises, shallowMount } from '@vue/test-utils';
+
+describe(`a group of tests`, () => {
+  beforeEach((context) => {
+    context.mockGet(`my-init-data`, { data: { getTest: true } });
+  });
+
+  test(`first`, async (context) => {
+    const wrapper = shallowMount(MyComponentWithApiCalls);
+    await flushPromises();
+    // …the rest of my first test
+  });
+
+  test(`second`, async (context) => {
+    const wrapper = shallowMount(MyComponentWithApiCalls);
+    await flushPromises();
+    // …the rest of my second test
+  });
+});
+```
+
+## Prefer using JSON mock for data
+
+:::tip  
+It's more convenient to use JSON as mock.  
+We can copy/paste a query response.  
+This will also act as a reference to the API responses.  
+:::
+
+Mocks data could be close to our `vue-query` composable
+
+```
+ src
+   └─ domain
+      └─ composables 
+        ├─ __mocks__
+        │  └─ my-data.json
+        └─ resources
+           └─ my-composable.vue
+```
+
+We can then use it in our tests
+
+```ts
+import { flushPromises, shallowMount } from '@vue/test-utils';
+
+import SomeComponent from './some-component.vue';
+import myResourceResponse from '~/domain/composables/__mocks__/my-data.json';
+
+describe(`some component`, () => {
+  test(`it fetches something`, async (context) => {
+    // send my mock as data
+    context.mockGet(`my-resource`, { data: myResourceResponse });
+    const wrapper = shallowMount(SomeComponent);
+    await flushPromises();
+    // my component will be hydrated with `myResourceResponse`
+    // …the rest of my test
+  });
+});
+```
+
+## Trigger Vue Query side effects
+
+:::tip  
+We will need to run timers for that!
+:::
+
+When we need to wait for invalidation done in `onSuccess`:
+
+```ts
+test(`update success`, async (context) => {
+  vi.useFakeTimers(); // We should fake timers
+  context.mockGet(PROPERTY_API_URL, { data: propertyResponse });
+  const wrapper = shallowMount(ValuationFileCard);
+  await context.flushPromises();
+  wrapper.findComponent(UButton).vm.$emit(`files`, FILES);
+  await wrapper.vm.$nextTick();
+  // first requests
+  context.mockPost(VALUATION_API_URL, { data: FILE_UPLOADED });
+  context.mockPut(PROPERTY_API_URL, { data: propertyResponseWithValuation });
+  await flushPromises();
+  // invalidation
+  context.mockGet(PROPERTY_API_URL, { data: propertyResponseWithValuation });
+  context.mockGet(VALUATION_API_PDF, { data: pdfResponseBlob });
+  vi.runAllTimers(); // wait for `queryClient.invalidateQueries` to run
+  await context.flushPromises(); // requests
+  expect(wrapper.findComponent(FavertonFile).exists()).toBe(true);
+  // …expects
+});
+```
+
+## Debugging the calls
+
+You can trace either by:
+
+```
+VITE_TEST__DEBUG_FETCH_MOCK=true pnpm test
+```
+
+or adding into `.env.local`:  
+
+```
+VITE_TEST__DEBUG_FETCH_MOCK=true
+```
+
+You'll have this output in the console:
+
+```
+# mock is initialized
+📡 MOCK  http://localhost/api/profile/profiles?pageSize=100
+    200  GET api/profile/profiles { pageSize: 100 }
+# request is ongoing    
+🔄 FETCH http://localhost/api/profile/profiles?pageSize=100
+         GET api/profile/profiles { pageSize: '100' }
+# request has been completed
+🔚 DONE  http://localhost/api/profile/profiles?pageSize=100
+```
+
+::: tip  
+request ongoing log will be done only if you use `defineCookieApi()`/`defineTokenApi()` factory methods  
+:::  
+
+## Each call should be consumed
+
+::: info  
+Since MSW migration this behavior is broken.    
+You still have warnings outputted in the logs.  
+:::  
+
+:::warning   
+It is important to wait for each mock to be consumed.  
+If not, it can have side effects on the next tests!  
+**After each test, it will throw if some mocks aren't used**   
+:::
+
+
+See [Undici documentation](https://undici.nodejs.org/#/docs/api/MockAgent?id=mockagentassertnopendinginterceptorsoptions) for more details
+
+```
+UndiciError: 1 interceptor is pending:
+
+┌─────────┬────────┬────────────────────────┬─────────────┬─────────────┬────────────┬─────────────┬───────────┐
+│ (index) │ Method │        Origin          │    Path     │ Status code │ Persistent │ Invocations │ Remaining │
+├─────────┼────────┼────────────────────────┼─────────────┼─────────────┼────────────┼─────────────┼───────────┤
+│    0    │ 'GET'  │ 'http://localhost.com' │ '/my-path'  │     200     │    '❌'    │      0      │     1     │
+└─────────┴────────┴────────────────────────┴─────────────┴─────────────┴────────────┴─────────────┴───────────┘
+```
+
+![The undici error](./assets/undici-error.png)

--- a/faverton-nuxt3/.gitignore
+++ b/faverton-nuxt3/.gitignore
@@ -186,3 +186,6 @@ types/generated/
 # Error logs
 error.log
 access.log
+
+# doc test starter
+/doc/testing*

--- a/faverton-nuxt3/app/components/simulation/parameters/SimulationParameters.test.ts
+++ b/faverton-nuxt3/app/components/simulation/parameters/SimulationParameters.test.ts
@@ -1,0 +1,323 @@
+import { vi } from 'vitest';
+import { flushPromises, shallowMount } from '@vue/test-utils';
+import SimulationParameters from './SimulationParameters.vue';
+
+const mockUseAddSimulation = vi.hoisted(() => vi.fn());
+const mockUseMapStore = vi.hoisted(() => vi.fn());
+
+vi.mock(`~/composables/useSimulation`, () => ({
+  useAddSimulation: mockUseAddSimulation,
+}));
+
+vi.mock(`~/stores/map`, () => ({
+  useMapStore: mockUseMapStore,
+}));
+
+describe(`SimulationParameters Component`, () => {
+  beforeEach(() => {
+    // Reset des mocks avant chaque test
+    vi.clearAllMocks();
+  });
+
+  // Tests critiques priorité 1 - Regroupés par fonctionnalité
+  describe(`Validation du formulaire`, () => {
+    beforeEach(() => {
+      mockUseMapStore.mockReturnValue({
+        drawnArea: ref(0),
+        startDrawing: vi.fn(),
+      });
+    });
+
+    it(`désactive le bouton quand isFormValid est false`, () => {
+      const solarEnergyId = `solar-energy-123`;
+      const wrapper = shallowMount(SimulationParameters, {
+        props: {
+          modelValue: 0,
+          addressProperty: null,
+          responseSolarEnergyId: { solarEnergyId } as SolarEnergyResponse | null,
+        },
+      });
+
+      const simulationButton = wrapper.findAllComponents({ name: `UButton` })
+        .find(btn => btn.props(`label`) === `Lancer la simulation`);
+
+      expect(simulationButton?.props(`disabled`)).toBe(true);
+    });
+
+    it(`active le bouton quand tous les champs requis sont remplis`, async () => {
+      const wrapper = shallowMount(SimulationParameters, {
+        props: {
+          modelValue: 0,
+          addressProperty: { postcode: `78430`, city: `Louveciennes` },
+          responseSolarEnergyId: { solarEnergyId: `test` } as SolarEnergyResponse,
+        },
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const vm = wrapper.vm as any;
+      vm.panelId = `panel-123`;
+      vm.surface = 50;
+
+      await nextTick();
+
+      const simulationButton = wrapper.findAllComponents({ name: `UButton` })
+        .find(btn => btn.props(`label`) === `Lancer la simulation`);
+
+      expect(simulationButton?.props(`disabled`)).toBe(false);
+    });
+  });
+
+  describe(`Gestion de la simulation`, () => {
+    beforeEach(() => {
+      mockUseMapStore.mockReturnValue({
+        drawnArea: ref(0),
+        startDrawing: vi.fn(),
+      });
+    });
+
+    it(`appelle useAddSimulation avec les bons paramètres lors du handleStart`, async () => {
+      const mockSimulationResponse = {
+        id: `simulation-123`,
+        estimatedProduction: 1000,
+      };
+      mockUseAddSimulation.mockResolvedValue(mockSimulationResponse);
+
+      const solarEnergyId = `solar-energy-123`;
+      const panelId = `panel-456`;
+
+      const wrapper = shallowMount(SimulationParameters, {
+        props: {
+          modelValue: 0,
+          addressProperty: { postcode: `78430`, city: `Louveciennes` },
+          responseSolarEnergyId: { solarEnergyId } as SolarEnergyResponse,
+        },
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const vm = wrapper.vm as any;
+      vm.panelId = panelId;
+      vm.surface = 75;
+      await nextTick();
+
+      const simulationButton = wrapper.findAllComponents({ name: `UButton` })
+        .find(btn => btn.props(`label`) === `Lancer la simulation`);
+
+      await simulationButton?.trigger(`click`);
+      await flushPromises();
+
+      expect(mockUseAddSimulation).toHaveBeenCalledTimes(1);
+      expect(mockUseAddSimulation).toHaveBeenCalledWith(solarEnergyId, panelId);
+    });
+
+    it(`émet update:simulation avec les données correctes`, async () => {
+      const mockSimulationResponse = {
+        id: `simulation-123`,
+        estimatedProduction: 1000,
+      };
+      mockUseAddSimulation.mockResolvedValue(mockSimulationResponse);
+
+      const wrapper = shallowMount(SimulationParameters, {
+        props: {
+          modelValue: 0,
+          addressProperty: { postcode: `78430`, city: `Louveciennes` },
+          responseSolarEnergyId: { solarEnergyId: `solar-123` } as SolarEnergyResponse,
+        },
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const vm = wrapper.vm as any;
+      vm.panelId = `panel-456`;
+      vm.surface = 75;
+      await nextTick();
+
+      const simulationButton = wrapper.findAllComponents({ name: `UButton` })
+        .find(btn => btn.props(`label`) === `Lancer la simulation`);
+
+      await simulationButton?.trigger(`click`);
+      await flushPromises();
+
+      const emittedEvents = wrapper.emitted(`update:simulation`);
+      expect(emittedEvents).toBeTruthy();
+      expect(emittedEvents?.[0]?.[0]).toEqual({
+        ...mockSimulationResponse,
+        surface: 75,
+      });
+    });
+
+    it(`passe à l'étape suivante après succès de handleStart`, async () => {
+      mockUseAddSimulation.mockResolvedValue({
+        id: `simulation-123`,
+        estimatedProduction: 1000,
+      });
+
+      const wrapper = shallowMount(SimulationParameters, {
+        props: {
+          modelValue: 0,
+          addressProperty: { postcode: `78430`, city: `Louveciennes` },
+          responseSolarEnergyId: { solarEnergyId: `solar-123` } as SolarEnergyResponse,
+        },
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const vm = wrapper.vm as any;
+      vm.panelId = `panel-456`;
+      vm.surface = 75;
+      await nextTick();
+
+      const simulationButton = wrapper.findAllComponents({ name: `UButton` })
+        .find(btn => btn.props(`label`) === `Lancer la simulation`);
+
+      await simulationButton?.trigger(`click`);
+      await flushPromises();
+
+      const emittedModelValue = wrapper.emitted(`update:modelValue`);
+      expect(emittedModelValue).toBeTruthy();
+      expect(emittedModelValue?.[0]?.[0]).toBe(1);
+    });
+
+    it(`ne fait rien si responseSolarEnergyId est null`, async () => {
+      const wrapper = shallowMount(SimulationParameters, {
+        props: {
+          modelValue: 0,
+          addressProperty: { postcode: `78430`, city: `Louveciennes` },
+          responseSolarEnergyId: null, // Cas d'échec
+        },
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const vm = wrapper.vm as any;
+      vm.panelId = `panel-456`;
+      vm.surface = 75;
+
+      const simulationButton = wrapper.findAllComponents({ name: `UButton` })
+        .find(btn => btn.props(`label`) === `Lancer la simulation`);
+
+      await simulationButton?.trigger(`click`);
+      await flushPromises();
+
+      expect(mockUseAddSimulation).not.toHaveBeenCalled();
+    });
+
+    it(`ne fait rien si panelId est null`, async () => {
+      const wrapper = shallowMount(SimulationParameters, {
+        props: {
+          modelValue: 0,
+          addressProperty: { postcode: `78430`, city: `Louveciennes` },
+          responseSolarEnergyId: { solarEnergyId: `solar-123` } as SolarEnergyResponse,
+        },
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const vm = wrapper.vm as any;
+      vm.panelId = null; // Cas d'échec
+      vm.surface = 75;
+
+      const simulationButton = wrapper.findAllComponents({ name: `UButton` })
+        .find(btn => btn.props(`label`) === `Lancer la simulation`);
+
+      await simulationButton?.trigger(`click`);
+      await flushPromises();
+
+      expect(mockUseAddSimulation).not.toHaveBeenCalled();
+    });
+  });
+
+  // Test priorité 2
+  describe(`Interaction avec la carte`, () => {
+    it(`synchronise surface avec mapStore.drawnArea`, async () => {
+      const mockDrawnArea = ref(0);
+      mockUseMapStore.mockReturnValue({
+        drawnArea: mockDrawnArea,
+        startDrawing: vi.fn(),
+      });
+
+      const wrapper = shallowMount(SimulationParameters, {
+        props: {
+          modelValue: 0,
+          addressProperty: { postcode: `78430`, city: `Louveciennes` },
+          responseSolarEnergyId: { solarEnergyId: `test` } as SolarEnergyResponse,
+        },
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const vm = wrapper.vm as any;
+      await nextTick();
+      // Test cas edge: drawnArea = 0 → surface = 1
+      vm.surface = mockDrawnArea.value > 0 ? mockDrawnArea.value : 1;
+      expect(vm.surface).toBe(1);
+
+      // Test cas normal: drawnArea > 0 → surface = drawnArea
+      mockDrawnArea.value = 150;
+      vm.surface = mockDrawnArea.value > 0 ? mockDrawnArea.value : 1;
+      expect(vm.surface).toBe(150);
+    });
+
+    it(`appelle startDrawing au clic sur le bouton dessiner`, async () => {
+      const mockStartDrawing = vi.fn();
+      mockUseMapStore.mockReturnValue({
+        drawnArea: ref(0),
+        startDrawing: mockStartDrawing,
+      });
+
+      const wrapper = shallowMount(SimulationParameters, {
+        props: {
+          modelValue: 0,
+          addressProperty: { postcode: `78430`, city: `Louveciennes` },
+          responseSolarEnergyId: { solarEnergyId: `test` } as SolarEnergyResponse,
+        },
+      });
+
+      await nextTick();
+
+      // Trouver le bouton "Dessiner" (pas celui de simulation)
+      const buttons = wrapper.findAllComponents({ name: `UButton` });
+      const drawButton = buttons.find(btn =>
+        btn.props(`label`) !== `Lancer la simulation`,
+      );
+
+      expect(drawButton).toBeDefined();
+
+      await drawButton?.trigger(`click`);
+
+      expect(mockStartDrawing).toHaveBeenCalledTimes(1);
+    });
+
+    it(`met surface à 1 quand drawnArea est 0`, async () => {
+      const mockDrawnArea = ref(0);
+
+      mockUseMapStore.mockReturnValue({
+        drawnArea: mockDrawnArea,
+        startDrawing: vi.fn(),
+      });
+
+      const wrapper = shallowMount(SimulationParameters, {
+        props: {
+          modelValue: 0,
+          addressProperty: { postcode: `78430`, city: `Louveciennes` },
+          responseSolarEnergyId: { solarEnergyId: `test` } as SolarEnergyResponse,
+        },
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const vm = wrapper.vm as any;
+      await nextTick();
+
+      expect(vm.surface).toBe(1);
+
+      // Test de la logique complète pour documenter le comportement
+      // Cas 1: drawnArea = 0 → surface = 1
+      vm.surface = mockDrawnArea.value > 0 ? mockDrawnArea.value : 1;
+      expect(vm.surface).toBe(1);
+
+      // Cas 2: drawnArea > 0 → surface = drawnArea
+      mockDrawnArea.value = 75;
+      vm.surface = mockDrawnArea.value > 0 ? mockDrawnArea.value : 1;
+      expect(vm.surface).toBe(75);
+
+      // Cas 3: Retour à 0 → surface = 1
+      mockDrawnArea.value = 0;
+      vm.surface = mockDrawnArea.value > 0 ? mockDrawnArea.value : 1;
+      expect(vm.surface).toBe(1);
+    });
+  });
+});

--- a/faverton-nuxt3/app/tests/e2e/user/login.e2e.spec.ts
+++ b/faverton-nuxt3/app/tests/e2e/user/login.e2e.spec.ts
@@ -12,7 +12,7 @@ test.describe(`Page de Login - Workflows utilisateur`, () => {
     await expect(page).toHaveURL(/.*\/user\/login/);
 
     // Vérifier que les éléments sont présents
-    await expect(page.locator(`input[type="email"]`)).toBeVisible();
+    await expect(page.locator(`input[type="email"]`)).toBeVisible({ timeout: 10000 });
     await expect(page.locator(`input[type="password"]`)).toBeVisible();
     await expect(page.locator(`button[type="submit"]`)).toBeVisible();
     await expect(page.locator(`text=Continuer`)).toBeVisible();

--- a/faverton-nuxt3/vitest.config.ts
+++ b/faverton-nuxt3/vitest.config.ts
@@ -15,4 +15,10 @@ export default defineVitestConfig({
       },
     },
   },
+  resolve: {
+    alias: {
+      '~/': new URL(`./app/`, import.meta.url).pathname,
+      '@/': new URL(`./app/`, import.meta.url).pathname,
+    },
+  },
 });


### PR DESCRIPTION
This pull request introduces several changes, including updates to testing configurations, component testing, and project documentation. The most significant changes involve adding comprehensive unit tests for the `SimulationParameters` component, updating `.gitignore` for testing files, and configuring path aliases for cleaner imports.

### Component Testing Enhancements:
* Added detailed unit tests for the `SimulationParameters` component to validate form behavior, simulation handling, and map interactions. These tests cover scenarios such as enabling/disabling buttons, handling invalid inputs, and synchronizing with the map store (`faverton-nuxt3/app/components/simulation/parameters/SimulationParameters.test.ts`).

### Project Configuration Updates:
* Introduced path aliases (`~/` and `@/`) in the `vitest.config.ts` file to simplify module imports (`faverton-nuxt3/vitest.config.ts`).

### Documentation and Ignored Files:
* Updated `.gitignore` to exclude testing-related files under `/doc/testing*` (`faverton-nuxt3/.gitignore`).
* Added a new prompt instruction file to guide responses, focusing on critical engagement and avoiding superficial compliments (`.github/instructions/prompt.instructions.md`).