### PR TITLE
fix(104): simulation - calcule  updates logic

### DIFF
--- a/faverton-nuxt3/server/api/simulation/price-year-batch/index.ts
+++ b/faverton-nuxt3/server/api/simulation/price-year-batch/index.ts
@@ -1,9 +1,10 @@
 import { serverSupabaseClient } from '#supabase/server';
 
+const EDF_PRICE = 0.1269;
+
 export default defineEventHandler(async (event) => {
   const body = await readBody(event);
   const client = await serverSupabaseClient(event);
-  const EDF_PRICE = 0.1269;
 
   if (!body.simulations || !Array.isArray(body.simulations)) {
     return {
@@ -26,7 +27,7 @@ export default defineEventHandler(async (event) => {
         results[solarEnergyId] = { error: 'Paramètres invalides' };
         return;
       }
-      const HIGH_PERFORMANCE_PANEL = Number((panelEfficiency / 100).toFixed(2));
+      const highPerformancePanel = Math.round((panelEfficiency / 100) * 100) / 100;
 
       try {
         const { data: solarEnergy } = await client
@@ -40,7 +41,7 @@ export default defineEventHandler(async (event) => {
           return;
         }
 
-        const amountEurosPerYear = solarEnergy.yearly_energy * surfaceArea * EDF_PRICE * HIGH_PERFORMANCE_PANEL;
+        const amountEurosPerYear = solarEnergy.yearly_energy * surfaceArea * EDF_PRICE * highPerformancePanel;
 
         results[solarEnergyId] = {
           yearlyEnergy: solarEnergy.yearly_energy,

--- a/faverton-nuxt3/server/api/simulation/price-year-batch/index.ts
+++ b/faverton-nuxt3/server/api/simulation/price-year-batch/index.ts
@@ -3,6 +3,7 @@ import { serverSupabaseClient } from '#supabase/server';
 export default defineEventHandler(async (event) => {
   const body = await readBody(event);
   const client = await serverSupabaseClient(event);
+  const EDF_PRICE = 0.1269;
 
   if (!body.simulations || !Array.isArray(body.simulations)) {
     return {
@@ -25,6 +26,7 @@ export default defineEventHandler(async (event) => {
         results[solarEnergyId] = { error: 'Paramètres invalides' };
         return;
       }
+      const HIGH_PERFORMANCE_PANEL = Number((panelEfficiency / 100).toFixed(2));
 
       try {
         const { data: solarEnergy } = await client
@@ -38,23 +40,12 @@ export default defineEventHandler(async (event) => {
           return;
         }
 
-        // Utiliser la même logique que l'API de recalcul pour la cohérence
-        const efficiency = panelEfficiency / 100;
-        const basePowerPerM2 = 0.2; // kWp/m² pour 20% d'efficacité
-        const installedPowerKWp = surfaceArea * basePowerPerM2 * (efficiency / 0.2);
-
-        // Production ajustée : yearly_energy de la DB représente kWh/kWp/an
-        const adjustedYearlyEnergy = solarEnergy.yearly_energy * installedPowerKWp;
-
-        // Coût d'installation basé sur la puissance
-        const installationCostPerKWp = 2500; // €/kWp
-        const amountEurosPerYear = installedPowerKWp * installationCostPerKWp;
+        const amountEurosPerYear = solarEnergy.yearly_energy * surfaceArea * EDF_PRICE * HIGH_PERFORMANCE_PANEL;
 
         results[solarEnergyId] = {
-          yearlyEnergy: Math.round(adjustedYearlyEnergy),
+          yearlyEnergy: solarEnergy.yearly_energy,
           surfaceArea,
-          amountEurosPerYear: Math.round(amountEurosPerYear),
-          installedPowerKWp: Math.round(installedPowerKWp * 100) / 100,
+          amountEurosPerYear: amountEurosPerYear,
         };
       }
       catch {


### PR DESCRIPTION
This pull request updates the calculation logic for solar energy simulations in the `faverton-nuxt3/server/api/simulation/price-year-batch/index.ts` file. The changes simplify the formula for computing yearly energy costs and installation costs while introducing new constants for better readability and maintainability.

### Updates to calculation logic:

* **Added constants for clarity**: Introduced `EDF_PRICE` and `HIGH_PERFORMANCE_PANEL` constants to simplify calculations and improve code readability. [[1]](diffhunk://#diff-9948f02179992ef6a80ce4f9a82a0aa5c0348ab35ef031c482d0de228064b948R6) [[2]](diffhunk://#diff-9948f02179992ef6a80ce4f9a82a0aa5c0348ab35ef031c482d0de228064b948R29)
* **Simplified cost calculation formula**: Replaced the previous multi-step calculation for `amountEurosPerYear` with a single formula using the new constants. This change removes intermediate variables like `installedPowerKWp` and `adjustedYearlyEnergy`.