### PR TITLE
feat(107): simulation - update responsive for medium breakkpoint

### DIFF
--- a/faverton-nuxt3/app/pages/simulator/index.vue
+++ b/faverton-nuxt3/app/pages/simulator/index.vue
@@ -96,11 +96,11 @@ const authPromptInfo = {
         </template>
       </UBreadcrumb>
     </div>
-    <div class="flex flex-col-reverse md:flex-row">
+    <div class="flex flex-col-reverse lg:flex-row">
       <FavertonCard
         :class="[
           'transition-all duration-500 ease-in-out',
-          isMapVisible ? 'md:w-1/2' : 'md:w-full xl:px-96',
+          isMapVisible ? 'lg:w-1/2' : 'lg:w-full xl:px-96',
         ]"
       >
         <h1 class="text-xl text-center p-6">
@@ -145,7 +145,7 @@ const authPromptInfo = {
             'relative overflow-hidden',
             isResizing ? 'ring-2 ring-blue-400 ring-opacity-50' : '',
           ]"
-          class="md:w-1/2 rounded-lg shadow-lg my-10 mx-5 p-5 bg-gradient-to-br from-blue-50 to-green-50 border border-blue-200"
+          class="lg:w-1/2 rounded-lg shadow-lg my-10 mx-5 p-5 bg-gradient-to-br from-blue-50 to-green-50 border border-blue-200"
         >
           <!-- Indicateur de taille en haut à droite avec animation -->
           <Transition


### PR DESCRIPTION
This pull request updates the layout of the `simulator` page in `faverton-nuxt3` to improve responsiveness by replacing `md` (medium breakpoint) with `lg` (large breakpoint) in CSS class definitions. These changes ensure that the layout adapts better to larger screens.

### Layout improvements for responsiveness:

* Updated the `div` containing the `FavertonCard` component to use `lg:flex-row` instead of `md:flex-row` and adjusted width classes to use `lg` breakpoints for better responsiveness on larger screens. (`faverton-nuxt3/app/pages/simulator/index.vue`, [faverton-nuxt3/app/pages/simulator/index.vueL99-R103](diffhunk://#diff-a88d35e1925f35744227d688310105716c37d5af0094e4530e7aef744e891164L99-R103))
* Modified the container class for a resizable element to use `lg:w-1/2` instead of `md:w-1/2`, ensuring consistent layout behavior at the large breakpoint. (`faverton-nuxt3/app/pages/simulator/index.vue`, [faverton-nuxt3/app/pages/simulator/index.vueL148-R148](diffhunk://#diff-a88d35e1925f35744227d688310105716c37d5af0094e4530e7aef744e891164L148-R148))